### PR TITLE
Formatage des dates en JJ/MM/AAAA

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,7 +58,17 @@ SEX_CHOICES = ["F", "M", "Autre/NP"]
 def parse_date(s: str | None):
     if not s:
         return None
-    return datetime.strptime(s, "%Y-%m-%d").date()
+    for fmt in ("%Y-%m-%d", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(s, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+def fmt_date(d: date | None):
+    if not d:
+        return ""
+    return d.strftime("%d/%m/%Y")
 
 def age_years(dob: date | None, ref: date | None = None) -> int | None:
     if not dob:
@@ -76,7 +86,10 @@ def bucket_for_age(a: int | None):
 
 def page(content_html: str, **ctx):
     """Injecte un fragment HTML dans le layout de base."""
-    return render_template_string(TPL_BASE, content=render_template_string(content_html, **ctx))
+    return render_template_string(
+        TPL_BASE,
+        content=render_template_string(content_html, fmt_date=fmt_date, **ctx),
+    )
 
 # ============================
 # Routes
@@ -411,7 +424,7 @@ TPL_DASHBOARD = """
           <td class="text-secondary">{{ f.id }}</td>
           <td class="fw-semibold">{{ f.label or "—" }}</td>
           <td>{{ f.room_number or "—" }}</td>
-          <td>{{ f.arrival_date or "—" }}</td>
+          <td>{{ fmt_date(f.arrival_date) or "—" }}</td>
           <td><span class="badge text-bg-secondary">{{ f.persons.count() }}</span></td>
           <td class="text-end">
             <a class="btn btn-sm btn-outline-info" href="{{ url_for('persons_list', fid=f.id) }}"><i class="bi bi-arrow-right-circle"></i></a>
@@ -529,7 +542,7 @@ TPL_FAMILIES = """
           <td class="text-secondary">{{ f.id }}</td>
           <td class="fw-semibold">{{ f.label or "—" }}</td>
           <td>{{ f.room_number or "—" }}</td>
-          <td>{{ f.arrival_date or "—" }}</td>
+          <td>{{ fmt_date(f.arrival_date) or "—" }}</td>
           <td><span class="badge text-bg-secondary">{{ f.persons.count() }}</span></td>
           <td class="text-end">
             <a class="btn btn-sm btn-outline-info" href="{{ url_for('persons_list', fid=f.id) }}"><i class="bi bi-person-lines-fill"></i></a>
@@ -564,7 +577,7 @@ TPL_FAMILY_FORM = """
     </div>
     <div class="col-md-4">
       <div class="form-floating">
-        <input type="date" name="arrival_date" class="form-control" id="fl3" value="{{ family.arrival_date if family and family.arrival_date else '' }}">
+        <input type="text" name="arrival_date" class="form-control" id="fl3" value="{{ fmt_date(family.arrival_date) if family and family.arrival_date else '' }}" placeholder="jj/mm/aaaa" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}">
         <label for="fl3">Date d'arrivée</label>
       </div>
     </div>
@@ -595,7 +608,7 @@ TPL_PERSONS = """
           <td class="text-secondary">{{ p.id }}</td>
           <td class="fw-semibold">{{ p.last_name }}</td>
           <td>{{ p.first_name }}</td>
-          <td>{{ p.dob or "—" }}</td>
+          <td>{{ fmt_date(p.dob) or "—" }}</td>
           <td>{{ p.sex or "—" }}</td>
           <td>{{ p.age if p.age is not none else "—" }}</td>
           <td class="text-end">
@@ -630,7 +643,7 @@ TPL_PERSON_FORM = """
     </div>
     <div class="col-md-3">
       <div class="form-floating">
-        <input type="date" name="dob" class="form-control" id="p3" value="{{ person.dob if person and person.dob else '' }}">
+        <input type="text" name="dob" class="form-control" id="p3" value="{{ fmt_date(person.dob) if person and person.dob else '' }}" placeholder="jj/mm/aaaa" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}">
         <label for="p3">Date de naissance</label>
       </div>
     </div>


### PR DESCRIPTION
## Résumé
- formatage des dates via un helper `fmt_date` pour un affichage en JJ/MM/AAAA
- prise en charge du format français lors de la saisie (`parse_date` étendu) et mise à jour des tableaux et formulaires

## Tests
- `python -m py_compile app.py`
- `python - <<'PY'
from app import parse_date, fmt_date
sample = "31/12/2023"
d = parse_date(sample)
print('ISO:', d.isoformat())
print('Affichage:', fmt_date(d))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a73723cb2c83248f42c176a8dc70a7