### PR TITLE
Refactorisation des templates et ajout du sélecteur de thème

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="fr" data-bs-theme="{{ theme }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Kardex Hôtel Social{% endblock %}</title>
+  <!-- Bootswatch (Darkly) + Icons -->
+  <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/darkly/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+  <!-- DataTables -->
+  <link rel="stylesheet" href="https://cdn.datatables.net/2.0.8/css/dataTables.bootstrap5.min.css">
+  <!-- Chart.js + datalabels plugin -->
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
+  <style>
+    :root {
+      --card-radius: 18px;
+    }
+    .card { border-radius: var(--card-radius); }
+    .shadow-soft { box-shadow: 0 10px 30px rgba(0,0,0,.25); }
+    .badge-soft { background: rgba(var(--bs-body-color-rgb), .08); border: 1px solid rgba(var(--bs-body-color-rgb), .15); }
+    .table>thead { position: sticky; top: 0; background: rgba(var(--bs-body-bg-rgb), .85); backdrop-filter: blur(6px); }
+    .brand { font-weight: 800; letter-spacing: .6px; }
+    .nav-link.active { font-weight: 600; }
+    .form-floating>.form-control, .form-select { background: rgba(var(--bs-body-color-rgb), .04); }
+    .form-control, .form-select { color: var(--bs-body-color) !important; }
+    .form-control::placeholder { color: rgba(var(--bs-body-color-rgb), .5); }
+    .form-floating>label { color: rgba(var(--bs-body-color-rgb), .7); }
+    select.form-select { color: var(--bs-body-color) !important; background-color: var(--bs-body-bg) !important; }
+    select.form-select option { color: var(--bs-body-color) !important; background-color: var(--bs-body-bg) !important; }
+  </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg bg-body-tertiary border-bottom">
+  <div class="container">
+    <a class="navbar-brand brand" href="{{ url_for('dashboard') }}">
+      <i class="bi bi-houses-fill me-2"></i>Kardex Hôtel Social
+    </a>
+    <div class="ms-auto d-flex gap-2">
+      <div class="btn-group">
+        <button class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown">
+          <i class="bi bi-palette me-1"></i>Thème
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end">
+          <li><a class="dropdown-item {% if theme=='light' %}active{% endif %}" href="{{ url_for('set_theme', mode='light') }}">Clair</a></li>
+          <li><a class="dropdown-item {% if theme=='dark' %}active{% endif %}" href="{{ url_for('set_theme', mode='dark') }}">Sombre</a></li>
+        </ul>
+      </div>
+      <a class="btn btn-outline-info" href="{{ url_for('families_list') }}"><i class="bi bi-people me-1"></i>Familles</a>
+      <div class="btn-group">
+        <button class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown">
+          <i class="bi bi-download me-1"></i>Export
+        </button>
+        <ul class="dropdown-menu dropdown-menu-end">
+          <li><a class="dropdown-item" href="{{ url_for('export_families_csv') }}">Familles (CSV)</a></li>
+          <li><a class="dropdown-item" href="{{ url_for('export_persons_csv') }}">Personnes (CSV)</a></li>
+        </ul>
+      </div>
+      <a class="btn btn-outline-success" href="{{ url_for('backup') }}"><i class="bi bi-save me-1"></i>Sauvegarde</a>
+      <a class="btn btn-outline-warning" href="{{ url_for('restore') }}"><i class="bi bi-arrow-counterclockwise me-1"></i>Restaurer</a>
+      <a class="btn btn-primary" href="{{ url_for('families_new') }}"><i class="bi bi-plus-lg me-1"></i>Nouvelle famille</a>
+    </div>
+  </div>
+</nav>
+
+<main class="container py-4">
+  {% block content %}{% endblock %}
+</main>
+
+<footer class="border-top py-3">
+  <div class="container small text-secondary">
+    <span>Local only. SQLite: <code>hotel_social.db</code></span>
+  </div>
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.datatables.net/2.0.8/js/dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/2.0.8/js/dataTables.bootstrap5.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const styles = getComputedStyle(document.documentElement);
+  Chart.defaults.color = styles.getPropertyValue('--bs-body-color');
+  Chart.defaults.borderColor = styles.getPropertyValue('--bs-border-color-translucent');
+});
+</script>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,136 @@
+{% extends 'base.html' %}
+{% block title %}Tableau de bord - Kardex Hôtel Social{% endblock %}
+{% block content %}
+{% if birthdays %}
+<div class="alert alert-warning d-flex align-items-center mb-4">
+  <i class="bi bi-cake2 me-2"></i>
+  <div>
+    Anniversaire{% if birthdays|length > 1 %}s{% endif %} aujourd'hui :
+    {% for p in birthdays %}
+      <strong>{{ p.first_name }} {{ p.last_name }}</strong>
+      <span class="text-secondary">({{ p.family.label }})</span>{% if not loop.last %}, {% endif %}
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
+<div class="row g-4">
+  <div class="col-12 col-xl-4">
+    <div class="card shadow-soft p-3">
+      <div class="d-flex align-items-center">
+        <div class="display-6 me-3 text-info"><i class="bi bi-people-fill"></i></div>
+        <div>
+          <div class="text-secondary text-uppercase small">Total clients</div>
+          <div class="h3 m-0">{{ total_clients }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="col-12 col-xl-4">
+    <div class="card shadow-soft p-3">
+      <h6 class="mb-3"><i class="bi bi-gender-ambiguous me-2"></i>Répartition par sexe</h6>
+      <canvas id="sexChart" height="200"></canvas>
+    </div>
+  </div>
+  <div class="col-12 col-xl-4">
+    <div class="card shadow-soft p-3">
+      <h6 class="mb-3"><i class="bi bi-activity me-2"></i>Tranches d’âge</h6>
+      <canvas id="ageChart" height="200"></canvas>
+      <div id="ageLegend" class="mt-2">
+        {% for lbl in age_labels %}
+        <div class="d-flex align-items-center mb-1">
+          <span class="me-1" style="width:12px;height:12px;background-color:{{ age_colors_f[loop.index0] }};display:inline-block;border-radius:2px;"></span>
+          <span class="me-2" style="width:12px;height:12px;background-color:{{ age_colors_m[loop.index0] }};display:inline-block;border-radius:2px;"></span>
+          <span class="small">{{ lbl }}</span>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="card shadow-soft p-3 mt-4">
+  <div class="d-flex align-items-center justify-content-between">
+    <h6 class="mb-0"><i class="bi bi-clock-history me-2"></i>Familles récentes</h6>
+    <span class="badge rounded-pill badge-soft">{{ families|length }} familles</span>
+  </div>
+  <div class="table-responsive mt-3" style="max-height: 420px;">
+    <table class="table table-hover align-middle table-sm">
+      <thead>
+        <tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th><th>Personnes</th><th></th></tr>
+      </thead>
+      <tbody>
+      {% for f in families %}
+        <tr>
+          <td class="text-secondary">{{ f.id }}</td>
+          <td class="fw-semibold">{{ f.label or "—" }}</td>
+          <td>{{ f.room_number or "—" }}</td>
+          <td>{{ fmt_date(f.arrival_date) or "—" }}</td>
+          <td><span class="badge text-bg-secondary">{{ f.persons.count() }}</span></td>
+          <td class="text-end">
+            <a class="btn btn-sm btn-outline-info" href="{{ url_for('persons_list', fid=f.id) }}"><i class="bi bi-arrow-right-circle"></i></a>
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  Chart.register(ChartDataLabels);
+
+  window.activeCharts = [];
+  window.activeCharts.push(new Chart(document.getElementById('sexChart'), {
+    type: 'doughnut',
+    data: {
+      labels: {{ sex_labels|tojson }},
+      datasets: [{
+        data: {{ sex_values|tojson }},
+        backgroundColor: ['#e83e8c', '#007bff', '#6c757d']
+      }]
+    },
+    options: {
+      plugins: {
+        legend: { position: 'bottom' },
+        datalabels: {
+          formatter: (v) => v || '',
+          font: { weight: 600 }
+        }
+      },
+      cutout: '60%'
+    }
+  }));
+
+  const ageColorsF = {{ age_colors_f|tojson }};
+  const ageColorsM = {{ age_colors_m|tojson }};
+  window.activeCharts.push(new Chart(document.getElementById('ageChart'), {
+    type: 'bar',
+    data: {
+      labels: {{ age_labels|tojson }},
+      datasets: [
+        {
+          label: 'Femmes',
+          data: {{ age_f_values|tojson }},
+          backgroundColor: ageColorsF
+        },
+        {
+          label: 'Hommes',
+          data: {{ age_m_values|tojson }},
+          backgroundColor: ageColorsM
+        }
+      ]
+    },
+    options: {
+      plugins: {
+        legend: { display: false },
+        datalabels: { anchor: 'end', align: 'top', formatter: v => v || '' }
+      },
+      scales: { y: { beginAtZero: true, ticks: { precision: 0 } } }
+    }
+  }));
+});
+</script>
+{% endblock %}

--- a/templates/families.html
+++ b/templates/families.html
@@ -1,0 +1,75 @@
+{% extends 'base.html' %}
+{% block title %}Familles - Kardex Hôtel Social{% endblock %}
+{% block content %}
+<div class="card shadow-soft p-3">
+  <div class="d-flex flex-wrap gap-2 justify-content-between align-items-end">
+    <h4 class="m-0"><i class="bi bi-people me-2"></i>Familles</h4>
+    <form class="row g-2" method="get">
+      <div class="col-auto">
+        <div class="form-floating">
+          <input class="form-control" name="label" id="f1" placeholder="Label" value="{{ label }}">
+          <label for="f1">Label</label>
+        </div>
+      </div>
+      <div class="col-auto">
+        <div class="form-floating">
+          <input class="form-control" name="room" id="f2" placeholder="Chambre" value="{{ room }}">
+          <label for="f2">Chambre</label>
+        </div>
+      </div>
+      <div class="col-auto">
+        <div class="form-floating">
+          <input type="date" class="form-control" name="dmin" id="f3" value="{{ dmin }}">
+          <label for="f3">Arrivée min</label>
+        </div>
+      </div>
+      <div class="col-auto">
+        <div class="form-floating">
+          <input type="date" class="form-control" name="dmax" id="f4" value="{{ dmax }}">
+          <label for="f4">Arrivée max</label>
+        </div>
+      </div>
+      <div class="col-auto">
+        <button class="btn btn-outline-info"><i class="bi bi-search"></i></button>
+        <a class="btn btn-outline-secondary" href="{{ url_for('families_list') }}"><i class="bi bi-x-lg"></i></a>
+        <a class="btn btn-primary" href="{{ url_for('families_new') }}"><i class="bi bi-plus-lg me-1"></i>Nouvelle famille</a>
+      </div>
+    </form>
+  </div>
+
+  <div class="table-responsive mt-3" style="max-height: 60vh;">
+    <table id="familiesTable" class="table table-hover table-sm align-middle">
+      <thead><tr><th>#</th><th>Label</th><th>Chambre</th><th>Arrivée</th><th>Personnes</th><th class="text-end">Actions</th></tr></thead>
+      <tbody>
+      {% for f in families %}
+        <tr>
+          <td class="text-secondary">{{ f.id }}</td>
+          <td class="fw-semibold">{{ f.label or "—" }}</td>
+          <td>{{ f.room_number or "—" }}</td>
+          <td>{{ fmt_date(f.arrival_date) or "—" }}</td>
+          <td><span class="badge text-bg-secondary">{{ f.persons.count() }}</span></td>
+          <td class="text-end">
+            <a class="btn btn-sm btn-outline-info" href="{{ url_for('persons_list', fid=f.id) }}"><i class="bi bi-person-lines-fill"></i></a>
+            <a class="btn btn-sm btn-outline-warning" href="{{ url_for('families_edit', fid=f.id) }}"><i class="bi bi-pencil-square"></i></a>
+            <form method="post" action="{{ url_for('families_delete', fid=f.id) }}" class="d-inline" onsubmit="return confirm('Supprimer la famille et ses membres ?');">
+              <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash3"></i></button>
+            </form>
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  new DataTable('#familiesTable', {
+    columnDefs: [{ orderable: false, targets: [5] }],
+    language: { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' }
+  });
+});
+</script>
+{% endblock %}

--- a/templates/family_form.html
+++ b/templates/family_form.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block title %}Famille - Kardex Hôtel Social{% endblock %}
+{% block content %}
+<div class="card shadow-soft p-3">
+  <h4 class="mb-3">{{ 'Modifier la famille' if family else 'Nouvelle famille' }}</h4>
+  <form method="post" class="row g-3">
+    <div class="col-md-5">
+      <div class="form-floating">
+        <input name="label" class="form-control" id="fl1" placeholder="Label" value="{{ family.label if family else '' }}">
+        <label for="fl1">Label (ex: Famille Dupont)</label>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="form-floating">
+        <input name="room_number" class="form-control" id="fl2" placeholder="Chambre" value="{{ family.room_number if family else '' }}">
+        <label for="fl2">Chambre</label>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="form-floating">
+        <input type="text" name="arrival_date" class="form-control" id="fl3" value="{{ fmt_date(family.arrival_date) if family and family.arrival_date else '' }}" placeholder="jj/mm/aaaa" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}">
+        <label for="fl3">Date d'arrivée</label>
+      </div>
+    </div>
+    <div class="col-12 d-flex gap-2">
+      <button class="btn btn-primary"><i class="bi bi-check2-circle me-1"></i>Enregistrer</button>
+      <a class="btn btn-outline-secondary" href="{{ url_for('families_list') }}">Annuler</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/templates/person_form.html
+++ b/templates/person_form.html
@@ -1,0 +1,41 @@
+{% extends 'base.html' %}
+{% block title %}Personne - Kardex Hôtel Social{% endblock %}
+{% block content %}
+<div class="card shadow-soft p-3">
+  <h4 class="mb-3">{{ 'Modifier' if person else 'Ajouter' }} une personne <span class="text-secondary">dans {{ family.label or 'Famille' }}</span></h4>
+  <form method="post" class="row g-3">
+    <div class="col-md-3">
+      <div class="form-floating">
+        <input name="last_name" class="form-control" id="p1" placeholder="Nom" value="{{ person.last_name if person else '' }}" required>
+        <label for="p1">Nom</label>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="form-floating">
+        <input name="first_name" class="form-control" id="p2" placeholder="Prénom" value="{{ person.first_name if person else '' }}" required>
+        <label for="p2">Prénom</label>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="form-floating">
+        <input type="text" name="dob" class="form-control" id="p3" value="{{ fmt_date(person.dob) if person and person.dob else '' }}" placeholder="jj/mm/aaaa" pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}">
+        <label for="p3">Date de naissance</label>
+      </div>
+    </div>
+    <div class="col-md-3">
+      <div class="form-floating">
+        <select name="sex" class="form-select" id="p4">
+          {% for s in sex_choices %}
+            <option value="{{ s }}" {% if person and person.sex==s %}selected{% endif %}>{{ s }}</option>
+          {% endfor %}
+        </select>
+        <label for="p4">Sexe</label>
+      </div>
+    </div>
+    <div class="col-12 d-flex gap-2">
+      <button class="btn btn-primary"><i class="bi bi-check2-circle me-1"></i>Enregistrer</button>
+      <a class="btn btn-outline-secondary" href="{{ url_for('persons_list', fid=family.id) }}">Annuler</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/templates/persons.html
+++ b/templates/persons.html
@@ -1,0 +1,67 @@
+{% extends 'base.html' %}
+{% block title %}Personnes - Kardex Hôtel Social{% endblock %}
+{% block content %}
+<div class="d-flex align-items-center justify-content-between mb-3">
+  <h4 class="m-0"><i class="bi bi-person-lines-fill me-2"></i>{{ family.label or 'Famille' }} <span class="text-secondary">| Chambre {{ family.room_number or '—' }}</span></h4>
+  <div class="d-flex gap-2">
+    <a class="btn btn-outline-secondary" href="{{ url_for('families_list') }}"><i class="bi bi-arrow-left"></i> Retour</a>
+    <a class="btn btn-primary" href="{{ url_for('persons_new', fid=family.id) }}"><i class="bi bi-plus-lg me-1"></i>Ajouter une personne</a>
+  </div>
+</div>
+
+<div class="card shadow-soft p-3">
+  <div class="table-responsive">
+    <table id="personsTable" class="table table-hover table-sm align-middle">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Nom</th>
+          <th>Prénom</th>
+          <th>Naissance</th>
+          <th>Sexe</th>
+          <th>Âge</th>
+          <th class="text-end">Actions</th>
+          <th>Chambre</th>
+          <th>Arrivée</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for p in persons %}
+        <tr>
+          <td class="text-secondary">{{ p.id }}</td>
+          <td class="fw-semibold">{{ p.last_name }}</td>
+          <td>{{ p.first_name }}</td>
+          <td data-order="{{ p.dob.isoformat() if p.dob else '' }}">{{ fmt_date(p.dob) or "—" }}</td>
+          <td>{{ p.sex or "—" }}</td>
+          <td>{{ p.age if p.age is not none else "—" }}</td>
+          <td class="text-end">
+            <a class="btn btn-sm btn-outline-warning" href="{{ url_for('persons_edit', fid=family.id, pid=p.id) }}"><i class="bi bi-pencil"></i></a>
+            <form method="post" action="{{ url_for('persons_delete', fid=family.id, pid=p.id) }}" class="d-inline" onsubmit="return confirm('Supprimer cette personne ?');">
+              <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash3"></i></button>
+            </form>
+          </td>
+          <td>{{ family.room_number or "—" }}</td>
+          <td data-order="{{ family.arrival_date.isoformat() if family.arrival_date else '' }}">{{ fmt_date(family.arrival_date) or "—" }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  new DataTable('#personsTable', {
+    columnDefs: [
+      { orderable: false, targets: [0,5,6,7,8] },
+      { visible: false, targets: [7,8] }
+    ],
+    language: {
+      url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json'
+    }
+  });
+});
+</script>
+{% endblock %}

--- a/templates/restore.html
+++ b/templates/restore.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block title %}Restauration - Kardex Hôtel Social{% endblock %}
+{% block content %}
+<div class="card shadow-soft p-3 col-md-6 mx-auto">
+  <h4 class="mb-3">Restauration</h4>
+  <div class="alert alert-warning">Cette opération effacera toutes les données existantes.</div>
+  <form method="post" enctype="multipart/form-data" onsubmit="return confirm('Cette action écrasera les données actuelles. Continuer ?');">
+    <div class="mb-3">
+      <input type="file" name="file" accept="application/json" class="form-control" required>
+    </div>
+    <button class="btn btn-danger" name="confirm" value="yes"><i class="bi bi-arrow-counterclockwise me-1"></i>Restaurer</button>
+    <a class="btn btn-outline-secondary" href="{{ url_for('dashboard') }}">Annuler</a>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Résumé
- externalisation des gabarits HTML et suppression des templates inline
- ajout d'un sélecteur de thème via cookie et route dédiée
- intégration des tableaux dynamiques DataTables pour les listes de familles et de personnes

## Tests
- `python -m py_compile app.py`
- script de test Flask pour vérifier les principales routes


------
https://chatgpt.com/codex/tasks/task_e_68a747f5006c8324b5f91dba629bc29b