### PR TITLE
Ajout des recherches et des résidents

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -42,6 +42,8 @@
         <i class="bi {% if theme=='dark' %}bi-moon-stars-fill{% else %}bi-sun-fill{% endif %}"></i>
       </button>
       <a class="btn btn-outline-info" href="{{ url_for('families_list') }}"><i class="bi bi-people me-1"></i>Familles</a>
+      <a class="btn btn-outline-info" href="{{ url_for('residents_list') }}"><i class="bi bi-person-lines-fill me-1"></i>Résidents</a>
+      <a class="btn btn-outline-info" href="{{ url_for('search') }}"><i class="bi bi-search me-1"></i>Recherches</a>
       <div class="btn-group">
         <button class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown">
           <i class="bi bi-download me-1"></i>Export

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -21,6 +21,7 @@
         <div>
           <div class="text-secondary text-uppercase small">Total clients</div>
           <div class="h3 m-0">{{ total_clients }}</div>
+          <div class="small text-secondary">{{ female_count }} femmes, {{ male_count }} hommes, {{ children_count }} enfants</div>
         </div>
       </div>
     </div>
@@ -45,9 +46,9 @@
           <span class="small">Hommes</span>
         </div>
       </div>
-      <div id="ageLegend" class="mt-2">
+      <div id="ageLegend" class="mt-2 d-flex flex-column align-items-center">
         {% for lbl in age_labels %}
-        <div class="d-flex align-items-center mb-1">
+        <div class="d-flex align-items-center justify-content-center mb-1">
           <span class="me-1" style="width:12px;height:12px;background-color:{{ age_colors_f[loop.index0] }};display:inline-block;border-radius:2px;"></span>
           <span class="me-2" style="width:12px;height:12px;background-color:{{ age_colors_m[loop.index0] }};display:inline-block;border-radius:2px;"></span>
           <span class="small">{{ lbl }}</span>

--- a/templates/families.html
+++ b/templates/families.html
@@ -49,6 +49,7 @@
           <td>{{ fmt_date(f.arrival_date) or "—" }}</td>
           <td><span class="badge text-bg-secondary">{{ f.persons.count() }}</span></td>
           <td class="text-end">
+            <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#famModal{{ f.id }}"><i class="bi bi-eye"></i></button>
             <a class="btn btn-sm btn-outline-info" href="{{ url_for('persons_list', fid=f.id) }}"><i class="bi bi-person-lines-fill"></i></a>
             <a class="btn btn-sm btn-outline-warning" href="{{ url_for('families_edit', fid=f.id) }}"><i class="bi bi-pencil-square"></i></a>
             <form method="post" action="{{ url_for('families_delete', fid=f.id) }}" class="d-inline" onsubmit="return confirm('Supprimer la famille et ses membres ?');">
@@ -61,6 +62,29 @@
     </table>
   </div>
 </div>
+
+{% for f in families %}
+<div class="modal fade" id="famModal{{ f.id }}" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">{{ f.label or 'Famille' }}</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <p><strong>Chambre :</strong> {{ f.room_number or '—' }}</p>
+        <p><strong>Arrivée :</strong> {{ fmt_date(f.arrival_date) or '—' }}</p>
+        <hr>
+        <ul class="list-unstyled mb-0">
+          {% for p in f.persons.order_by(Person.id.asc()).all() %}
+          <li>{{ p.first_name }} {{ p.last_name }} – {{ age_years(p.dob) or '—' }} ans</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+{% endfor %}
 {% endblock %}
 
 {% block scripts %}

--- a/templates/residents.html
+++ b/templates/residents.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+{% block title %}Résidents - Kardex Hôtel Social{% endblock %}
+{% block content %}
+<div class="card shadow-soft p-3">
+  <div class="table-responsive">
+    <table id="residentsTable" class="table table-hover table-sm align-middle">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Nom</th>
+          <th>Prénom</th>
+          <th>Sexe</th>
+          <th>Âge</th>
+          <th>Famille</th>
+          <th>Chambre</th>
+          <th>Arrivée</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for p in persons %}
+        <tr>
+          <td class="text-secondary">{{ p.id }}</td>
+          <td class="fw-semibold">{{ p.last_name }}</td>
+          <td>{{ p.first_name }}</td>
+          <td>{{ p.sex or "—" }}</td>
+          <td>{{ p.age if p.age is not none else "—" }}</td>
+          <td>{{ p.family_label or "—" }}</td>
+          <td>{{ p.room_number or "—" }}</td>
+          <td data-order="{{ p.arrival_date.isoformat() if p.arrival_date else '' }}">{{ fmt_date(p.arrival_date) or "—" }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  new DataTable('#residentsTable', {
+    language: { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' }
+  });
+});
+</script>
+{% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,125 @@
+{% extends 'base.html' %}
+{% block title %}Recherches - Kardex Hôtel Social{% endblock %}
+{% block content %}
+<div class="row g-4">
+  <div class="col-12 col-lg-6">
+    <div class="card shadow-soft p-3 h-100">
+      <h5 class="mb-3">Recherche familles</h5>
+      <form class="row g-2 mb-3" method="get">
+        <div class="col-12">
+          <div class="form-floating">
+            <input class="form-control" name="fam_label" id="fam_label" value="{{ fam_label }}">
+            <label for="fam_label">Nom</label>
+          </div>
+        </div>
+        <div class="col-12">
+          <div class="form-floating">
+            <input class="form-control" name="fam_room" id="fam_room" value="{{ fam_room }}">
+            <label for="fam_room">Chambre</label>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="form-floating">
+            <input type="date" class="form-control" name="fam_arrival" id="fam_arrival" value="{{ fam_arrival }}">
+            <label for="fam_arrival">Arrivée exacte</label>
+          </div>
+        </div>
+        <div class="col-6"></div>
+        <div class="col-6">
+          <div class="form-floating">
+            <input type="date" class="form-control" name="fam_dmin" id="fam_dmin" value="{{ fam_dmin }}">
+            <label for="fam_dmin">Arrivée min</label>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="form-floating">
+            <input type="date" class="form-control" name="fam_dmax" id="fam_dmax" value="{{ fam_dmax }}">
+            <label for="fam_dmax">Arrivée max</label>
+          </div>
+        </div>
+        <div class="col-12">
+          <button class="btn btn-outline-info"><i class="bi bi-search"></i></button>
+          <a class="btn btn-outline-secondary" href="{{ url_for('search') }}"><i class="bi bi-x-lg"></i></a>
+        </div>
+      </form>
+      {% if families %}
+      <div class="table-responsive" style="max-height:40vh;">
+        <table class="table table-sm table-hover align-middle">
+          <thead><tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th></tr></thead>
+          <tbody>
+          {% for f in families %}
+            <tr>
+              <td class="text-secondary">{{ f.id }}</td>
+              <td>{{ f.label or '—' }}</td>
+              <td>{{ f.room_number or '—' }}</td>
+              <td>{{ fmt_date(f.arrival_date) or '—' }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+  <div class="col-12 col-lg-6">
+    <div class="card shadow-soft p-3 h-100">
+      <h5 class="mb-3">Recherche personnes</h5>
+      <form class="row g-2 mb-3" method="get">
+        <div class="col-6">
+          <div class="form-floating">
+            <input class="form-control" name="p_last" id="p_last" value="{{ p_last }}">
+            <label for="p_last">Nom</label>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="form-floating">
+            <input class="form-control" name="p_first" id="p_first" value="{{ p_first }}">
+            <label for="p_first">Prénom</label>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="form-floating">
+            <input type="date" class="form-control" name="p_dob" id="p_dob" value="{{ p_dob }}">
+            <label for="p_dob">Naissance</label>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="form-floating">
+            <input type="date" class="form-control" name="p_arrival" id="p_arrival" value="{{ p_arrival }}">
+            <label for="p_arrival">Arrivée</label>
+          </div>
+        </div>
+        <div class="col-12">
+          <div class="form-floating">
+            <input class="form-control" name="p_room" id="p_room" value="{{ p_room }}">
+            <label for="p_room">Chambre</label>
+          </div>
+        </div>
+        <div class="col-12">
+          <button class="btn btn-outline-info"><i class="bi bi-search"></i></button>
+          <a class="btn btn-outline-secondary" href="{{ url_for('search') }}"><i class="bi bi-x-lg"></i></a>
+        </div>
+      </form>
+      {% if persons %}
+      <div class="table-responsive" style="max-height:40vh;">
+        <table class="table table-sm table-hover align-middle">
+          <thead><tr><th>#</th><th>Nom</th><th>Prénom</th><th>Âge</th><th>Chambre</th><th>Arrivée</th></tr></thead>
+          <tbody>
+          {% for p in persons %}
+            <tr>
+              <td class="text-secondary">{{ p.id }}</td>
+              <td>{{ p.last_name }}</td>
+              <td>{{ p.first_name }}</td>
+              <td>{{ p.age if p.age is not none else '—' }}</td>
+              <td>{{ p.room_number or '—' }}</td>
+              <td>{{ fmt_date(p.arrival_date) or '—' }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Résumé
- Centrage de la légende des tranches d’âge et ajout du détail Femmes/Hommes/Enfants
- Bouton œil pour consulter les détails d’une famille et nouvelle page listant tous les résidents
- Ajout d’un onglet de recherches avancées pour familles et personnes

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a754f1242483248a4e55a0cf4ad134