### PR TITLE
Corrige affichage des statistiques adultes/enfants

### DIFF
--- a/app.py
+++ b/app.py
@@ -116,6 +116,9 @@ def dashboard():
     sex_counts = {k: 0 for k in SEX_CHOICES}
     # Tranches d'âge par sexe
     age_counts = {b[0]: {"F": 0, "M": 0} for b in AGE_BUCKETS}
+    # Comptages adultes/enfants détaillés
+    adult_female_count = adult_male_count = 0
+    girl_count = boy_count = 0
 
     for p in persons:
         s = p.sex if p.sex in sex_counts else "Autre/NP"
@@ -124,12 +127,17 @@ def dashboard():
         b = bucket_for_age(a)
         if b and s in ("F", "M"):
             age_counts[b][s] += 1
-
-    female_count = sex_counts.get("F", 0)
-    male_count = sex_counts.get("M", 0)
-    children_count = sum(
-        1 for p in persons if (age := age_years(p.dob, today)) is not None and age < 18
-    )
+        if a is not None and s in ("F", "M"):
+            if a < 18:
+                if s == "F":
+                    girl_count += 1
+                else:
+                    boy_count += 1
+            else:
+                if s == "F":
+                    adult_female_count += 1
+                else:
+                    adult_male_count += 1
 
     # Anniversaires du jour
     birthdays = [
@@ -152,9 +160,10 @@ def dashboard():
         age_colors_m=AGE_COLORS_M,
         families=families,
         birthdays=birthdays,
-        female_count=female_count,
-        male_count=male_count,
-        children_count=children_count,
+        adult_female_count=adult_female_count,
+        adult_male_count=adult_male_count,
+        girl_count=girl_count,
+        boy_count=boy_count,
     )
 
 # ----- Familles -----

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -21,7 +21,10 @@
         <div>
           <div class="text-secondary text-uppercase small">Total clients</div>
           <div class="h3 m-0">{{ total_clients }}</div>
-          <div class="small text-secondary">{{ female_count }} femmes, {{ male_count }} hommes, {{ children_count }} enfants</div>
+          <div class="small text-secondary">
+            Adultes : {{ adult_female_count }} femmes, {{ adult_male_count }} hommes<br>
+            Enfants : {{ girl_count }} filles, {{ boy_count }} garçons
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Résumé
- Calcule séparément les femmes et hommes adultes ainsi que les filles et garçons.
- Affiche le détail adultes/enfants dans le tableau de bord.

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a758a0701c8324b272f52c9ee73ec6