### PR TITLE
Corrige l'alerte de sur-occupation pour les familles multi-chambres

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 from io import StringIO
 import csv
 import json
+import re
 
 from flask import Flask, request, redirect, url_for, render_template, make_response
 from flask_sqlalchemy import SQLAlchemy
@@ -219,7 +220,8 @@ def dashboard():
 
     for f in families:
         persons_list = f.persons.all()
-        if f.room_number not in ("53", "54") and len(persons_list) > 3:
+        rooms = re.findall(r"\d+", f.room_number or "")
+        if len(rooms) == 1 and rooms[0] not in ("53", "54") and len(persons_list) > 3:
             overcrowded.append(f)
 
         has_adult_male = False


### PR DESCRIPTION
## Résumé
- ignore les familles réparties sur plusieurs chambres lors de la détection de sur-occupation
- ajoute l'analyse des numéros de chambre via `re`

## Test
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a78187e64c8324aa92e6463c7b08b9