### PR TITLE
Ajout du tri sur les familles et archives

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -44,7 +44,7 @@
       </form>
       {% if families %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table class="table table-sm table-hover align-middle">
+        <table id="archiveFamiliesTable" class="table table-sm table-hover align-middle">
           <thead><tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th><th>Départ</th></tr></thead>
           <tbody>
           {% for f in families %}
@@ -52,8 +52,8 @@
               <td class="text-secondary">{{ f.id }}</td>
               <td>{{ f.label or '—' }}</td>
               <td>{{ f.room_number or '—' }}</td>
-              <td>{{ fmt_date(f.arrival_date) or '—' }}</td>
-              <td>{{ fmt_date(f.departure_date) or '—' }}</td>
+              <td data-order="{{ f.arrival_date.isoformat() if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or '—' }}</td>
+              <td data-order="{{ f.departure_date.isoformat() if f.departure_date else '' }}">{{ fmt_date(f.departure_date) or '—' }}</td>
             </tr>
           {% endfor %}
           </tbody>
@@ -103,7 +103,7 @@
       </form>
       {% if persons %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table class="table table-sm table-hover align-middle">
+        <table id="archivePersonsTable" class="table table-sm table-hover align-middle">
           <thead><tr><th>#</th><th>Nom</th><th>Prénom</th><th>Âge</th><th>Chambre</th><th>Arrivée</th></tr></thead>
           <tbody>
           {% for p in persons %}
@@ -113,7 +113,7 @@
               <td>{{ p.first_name }}</td>
               <td>{{ p.age if p.age is not none else '—' }}</td>
               <td>{{ p.room_number or '—' }}</td>
-              <td>{{ fmt_date(p.arrival_date) or '—' }}</td>
+              <td data-order="{{ p.arrival_date.isoformat() if p.arrival_date else '' }}">{{ fmt_date(p.arrival_date) or '—' }}</td>
             </tr>
           {% endfor %}
           </tbody>
@@ -123,4 +123,18 @@
     </div>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const lang = { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' };
+  if (document.getElementById('archiveFamiliesTable')) {
+    new DataTable('#archiveFamiliesTable', { language: lang });
+  }
+  if (document.getElementById('archivePersonsTable')) {
+    new DataTable('#archivePersonsTable', { language: lang });
+  }
+});
+</script>
 {% endblock %}

--- a/templates/families.html
+++ b/templates/families.html
@@ -46,7 +46,7 @@
           <td class="text-secondary">{{ f.id }}</td>
           <td class="fw-semibold">{{ f.label or "—" }}</td>
           <td>{{ f.room_number or "—" }}</td>
-          <td>{{ fmt_date(f.arrival_date) or "—" }}</td>
+          <td data-order="{{ f.arrival_date.isoformat() if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or "—" }}</td>
           <td><span class="badge text-bg-secondary">{{ f.persons.count() }}</span></td>
           <td class="text-end">
             <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#famModal{{ f.id }}"><i class="bi bi-eye"></i></button>


### PR DESCRIPTION
## Résumé
- Tri chronologique des familles grâce à un `data-order` sur la date d'arrivée
- Tables d'archives transformées en DataTables pour trier par nom, chambre et dates

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a78557554c8324af36c5f7a748b89a