### PR TITLE
Ajout d'une seconde chambre par famille

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -51,7 +51,7 @@
             <tr>
               <td class="text-secondary">{{ f.id }}</td>
               <td>{{ f.label or '—' }}</td>
-              <td>{{ f.room_number or '—' }}</td>
+              <td>{{ rooms_text(f) or '—' }}</td>
               <td data-order="{{ f.arrival_date.isoformat() if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or '—' }}</td>
               <td data-order="{{ f.departure_date.isoformat() if f.departure_date else '' }}">{{ fmt_date(f.departure_date) or '—' }}</td>
             </tr>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -150,7 +150,7 @@
             <div class="fw-bold">Familles &gt;3 pers. dans une chambre (hors 53/54)</div>
             <ul class="mb-0 ps-3">
               {% for f in overcrowded_families %}
-                <li class="small">{{ f.label or "Famille " ~ f.id }} — chambre {{ f.room_number }} ({{ f.persons.count() }} pers.)</li>
+                <li class="small">{{ f.label or "Famille " ~ f.id }} — chambre {{ rooms_text(f) }} ({{ f.persons.count() }} pers.)</li>
               {% else %}
                 <li class="small">Aucune</li>
               {% endfor %}
@@ -163,7 +163,7 @@
             <div class="fw-bold">Femmes isolées</div>
             <ul class="mb-0 ps-3">
               {% for f in isolated_women_families %}
-                <li class="small">{{ f.label or "Famille " ~ f.id }} — chambre {{ f.room_number }}</li>
+                <li class="small">{{ f.label or "Famille " ~ f.id }} — chambre {{ rooms_text(f) }}</li>
               {% else %}
                 <li class="small">Aucune</li>
               {% endfor %}
@@ -176,7 +176,7 @@
             <div class="fw-bold">Bébés de moins d'un an</div>
             <ul class="mb-0 ps-3">
               {% for f in baby_families %}
-                <li class="small">{{ f.label or "Famille " ~ f.id }} — chambre {{ f.room_number }}</li>
+                <li class="small">{{ f.label or "Famille " ~ f.id }} — chambre {{ rooms_text(f) }}</li>
               {% else %}
                 <li class="small">Aucune</li>
               {% endfor %}
@@ -203,7 +203,7 @@
         <tr>
           <td class="text-secondary">{{ f.id }}</td>
           <td class="fw-semibold">{{ f.label or "—" }}</td>
-          <td>{{ f.room_number or "—" }}</td>
+          <td>{{ rooms_text(f) or "—" }}</td>
           <td>{{ fmt_date(f.arrival_date) or "—" }}</td>
           <td><span class="badge text-bg-secondary">{{ f.persons.count() }}</span></td>
           <td class="text-end">

--- a/templates/families.html
+++ b/templates/families.html
@@ -45,7 +45,7 @@
         <tr>
           <td class="text-secondary">{{ f.id }}</td>
           <td class="fw-semibold">{{ f.label or "—" }}</td>
-          <td>{{ f.room_number or "—" }}</td>
+          <td>{{ rooms_text(f) or "—" }}</td>
           <td data-order="{{ f.arrival_date.isoformat() if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or "—" }}</td>
           <td><span class="badge text-bg-secondary">{{ f.persons.count() }}</span></td>
           <td class="text-end">
@@ -73,7 +73,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
-        <p><strong>Chambre :</strong> {{ f.room_number or '—' }}</p>
+        <p><strong>Chambre :</strong> {{ rooms_text(f) or '—' }}</p>
         <p><strong>Arrivée :</strong> {{ fmt_date(f.arrival_date) or '—' }}</p>
         <hr>
         <ul class="list-unstyled mb-0">

--- a/templates/family_form.html
+++ b/templates/family_form.html
@@ -4,16 +4,22 @@
 <div class="card shadow-soft p-3">
   <h4 class="mb-3">{{ 'Modifier la famille' if family else 'Nouvelle famille' }}</h4>
   <form method="post" class="row g-3">
-    <div class="col-md-5">
+    <div class="col-md-4">
       <div class="form-floating">
         <input name="label" class="form-control" id="fl1" placeholder="Label" value="{{ family.label if family else '' }}">
         <label for="fl1">Label (ex: Famille Dupont)</label>
       </div>
     </div>
-    <div class="col-md-3">
+    <div class="col-md-2">
       <div class="form-floating">
         <input name="room_number" class="form-control" id="fl2" placeholder="Chambre" value="{{ family.room_number if family else '' }}">
-        <label for="fl2">Chambre</label>
+        <label for="fl2">Chambre 1</label>
+      </div>
+    </div>
+    <div class="col-md-2">
+      <div class="form-floating">
+        <input name="room_number2" class="form-control" id="fl2b" placeholder="Chambre 2" value="{{ family.room_number2 if family else '' }}">
+        <label for="fl2b">Chambre 2</label>
       </div>
     </div>
     <div class="col-md-4">

--- a/templates/persons.html
+++ b/templates/persons.html
@@ -2,7 +2,7 @@
 {% block title %}Personnes - Kardex Hôtel Social{% endblock %}
 {% block content %}
 <div class="d-flex align-items-center justify-content-between mb-3">
-  <h4 class="m-0"><i class="bi bi-person-lines-fill me-2"></i>{{ family.label or 'Famille' }} <span class="text-secondary">| Chambre {{ family.room_number or '—' }}</span></h4>
+  <h4 class="m-0"><i class="bi bi-person-lines-fill me-2"></i>{{ family.label or 'Famille' }} <span class="text-secondary">| Chambre {{ rooms_text(family) or '—' }}</span></h4>
   <div class="d-flex gap-2">
     <a class="btn btn-outline-secondary" href="{{ url_for('families_list') }}"><i class="bi bi-arrow-left"></i> Retour</a>
     <a class="btn btn-primary" href="{{ url_for('persons_new', fid=family.id) }}"><i class="bi bi-plus-lg me-1"></i>Ajouter une personne</a>
@@ -40,7 +40,7 @@
               <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash3"></i></button>
             </form>
           </td>
-          <td>{{ family.room_number or "—" }}</td>
+          <td>{{ rooms_text(family) or "—" }}</td>
           <td data-order="{{ family.arrival_date.isoformat() if family.arrival_date else '' }}">{{ fmt_date(family.arrival_date) or "—" }}</td>
         </tr>
       {% endfor %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -51,7 +51,7 @@
             <tr>
               <td class="text-secondary">{{ f.id }}</td>
               <td>{{ f.label or '—' }}</td>
-              <td>{{ f.room_number or '—' }}</td>
+              <td>{{ rooms_text(f) or '—' }}</td>
               <td>{{ fmt_date(f.arrival_date) or '—' }}</td>
             </tr>
           {% endfor %}


### PR DESCRIPTION
## Résumé
- prise en charge d'une deuxième chambre pour chaque famille
- adaptation des exports, recherches et affichages aux chambres multiples
- exclusion des familles multi-chambres des alertes de sur-occupation

## Tests
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68a89405a14c8324ac4d9bf72a47b180