### PR TITLE
Ajout du tri sur les listes

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -194,7 +194,7 @@
     <span class="badge rounded-pill badge-soft">{{ families|length }} familles</span>
   </div>
   <div class="table-responsive mt-3" style="max-height: 420px;">
-    <table class="table table-hover align-middle table-sm">
+    <table id="dashboardFamiliesTable" class="table table-hover align-middle table-sm">
       <thead>
         <tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th><th>Personnes</th><th></th></tr>
       </thead>
@@ -204,7 +204,7 @@
           <td class="text-secondary">{{ f.id }}</td>
           <td class="fw-semibold">{{ f.label or "—" }}</td>
           <td>{{ rooms_text(f) or "—" }}</td>
-          <td>{{ fmt_date(f.arrival_date) or "—" }}</td>
+          <td data-order="{{ f.arrival_date.isoformat() if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or "—" }}</td>
           <td><span class="badge text-bg-secondary">{{ f.persons.count() }}</span></td>
           <td class="text-end">
             <a class="btn btn-sm btn-outline-info" href="{{ url_for('persons_list', fid=f.id) }}"><i class="bi bi-arrow-right-circle"></i></a>
@@ -320,6 +320,9 @@ document.addEventListener('DOMContentLoaded', () => {
       scales: { y: { beginAtZero: true, ticks: { precision: 0 } } }
     }
   }));
+
+  const lang = { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' };
+  new DataTable('#dashboardFamiliesTable', { language: lang });
 });
 </script>
 {% endblock %}

--- a/templates/persons.html
+++ b/templates/persons.html
@@ -55,7 +55,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   new DataTable('#personsTable', {
     columnDefs: [
-      { orderable: false, targets: [0,5,6,7,8] },
+      { orderable: false, targets: [0,6,7,8] },
       { visible: false, targets: [7,8] }
     ],
     language: {

--- a/templates/search.html
+++ b/templates/search.html
@@ -44,7 +44,7 @@
       </form>
       {% if families %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table class="table table-sm table-hover align-middle">
+        <table id="searchFamiliesTable" class="table table-sm table-hover align-middle">
           <thead><tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th></tr></thead>
           <tbody>
           {% for f in families %}
@@ -52,7 +52,7 @@
               <td class="text-secondary">{{ f.id }}</td>
               <td>{{ f.label or '—' }}</td>
               <td>{{ rooms_text(f) or '—' }}</td>
-              <td>{{ fmt_date(f.arrival_date) or '—' }}</td>
+              <td data-order="{{ f.arrival_date.isoformat() if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or '—' }}</td>
             </tr>
           {% endfor %}
           </tbody>
@@ -102,7 +102,7 @@
       </form>
       {% if persons %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table class="table table-sm table-hover align-middle">
+        <table id="searchPersonsTable" class="table table-sm table-hover align-middle">
           <thead><tr><th>#</th><th>Nom</th><th>Prénom</th><th>Âge</th><th>Chambre</th><th>Arrivée</th></tr></thead>
           <tbody>
           {% for p in persons %}
@@ -112,7 +112,7 @@
               <td>{{ p.first_name }}</td>
               <td>{{ p.age if p.age is not none else '—' }}</td>
               <td>{{ p.room_number or '—' }}</td>
-              <td>{{ fmt_date(p.arrival_date) or '—' }}</td>
+              <td data-order="{{ p.arrival_date.isoformat() if p.arrival_date else '' }}">{{ fmt_date(p.arrival_date) or '—' }}</td>
             </tr>
           {% endfor %}
           </tbody>
@@ -122,4 +122,18 @@
     </div>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const lang = { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' };
+  if (document.getElementById('searchFamiliesTable')) {
+    new DataTable('#searchFamiliesTable', { language: lang });
+  }
+  if (document.getElementById('searchPersonsTable')) {
+    new DataTable('#searchPersonsTable', { language: lang });
+  }
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Résumé
- Activer le tri par colonnes pour les résultats de recherche
- Rendre le tableau de l'accueil triable
- Permettre le tri par âge dans la liste des personnes

## Tests
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9c97094588324a6d3fe184ad3be46