### PR TITLE
Fix DataTables sorting for persons and families

### DIFF
--- a/static/js/tables.js
+++ b/static/js/tables.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const commonOpts = {
+    ordering: true,
+    order: [],
+    language: { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' }
+  };
+
+  const init = (el) => {
+    const opts = { ...commonOpts };
+    const last = el.querySelector('thead th:last-child');
+    if (last && last.textContent.trim() === 'Actions') {
+      opts.columnDefs = [{ targets: -1, orderable: false }];
+    }
+    new DataTable(el, opts);
+  };
+
+  const persons = document.querySelector('#personsTable');
+  if (persons) init(persons);
+
+  const families = document.querySelector('#familiesTable');
+  if (families) init(families);
+});

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -44,16 +44,16 @@
       </form>
       {% if families %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table id="archiveFamiliesTable" class="table table-sm table-hover align-middle">
+        <table id="familiesTable" class="table table-striped table-hover table-sm align-middle">
           <thead><tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th><th>Départ</th></tr></thead>
           <tbody>
           {% for f in families %}
             <tr>
               <td class="text-secondary">{{ f.id }}</td>
               <td>{{ f.label or '—' }}</td>
-              <td>{{ rooms_text(f) or '—' }}</td>
-              <td data-order="{{ f.arrival_date.isoformat() if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or '—' }}</td>
-              <td data-order="{{ f.departure_date.isoformat() if f.departure_date else '' }}">{{ fmt_date(f.departure_date) or '—' }}</td>
+              <td data-order="{{ (rooms_text(f) or '')|int }}">{{ rooms_text(f) or '—' }}</td>
+              <td data-order="{{ f.arrival_date.strftime('%Y-%m-%d') if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or '—' }}</td>
+              <td data-order="{{ f.departure_date.strftime('%Y-%m-%d') if f.departure_date else '' }}">{{ fmt_date(f.departure_date) or '—' }}</td>
             </tr>
           {% endfor %}
           </tbody>
@@ -103,7 +103,7 @@
       </form>
       {% if persons %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table id="archivePersonsTable" class="table table-sm table-hover align-middle">
+        <table id="personsTable" class="table table-striped table-hover table-sm align-middle">
           <thead><tr><th>#</th><th>Nom</th><th>Prénom</th><th>Âge</th><th>Chambre</th><th>Arrivée</th></tr></thead>
           <tbody>
           {% for p in persons %}
@@ -111,9 +111,9 @@
               <td class="text-secondary">{{ p.id }}</td>
               <td>{{ p.last_name }}</td>
               <td>{{ p.first_name }}</td>
-              <td>{{ p.age if p.age is not none else '—' }}</td>
-              <td>{{ p.room_number or '—' }}</td>
-              <td data-order="{{ p.arrival_date.isoformat() if p.arrival_date else '' }}">{{ fmt_date(p.arrival_date) or '—' }}</td>
+              <td data-order="{{ p.age if p.age is not none else -1 }}">{{ p.age if p.age is not none else '—' }}</td>
+              <td data-order="{{ p.room_number|int if p.room_number else '' }}">{{ p.room_number or '—' }}</td>
+              <td data-order="{{ p.arrival_date.strftime('%Y-%m-%d') if p.arrival_date else '' }}">{{ fmt_date(p.arrival_date) or '—' }}</td>
             </tr>
           {% endfor %}
           </tbody>
@@ -125,16 +125,4 @@
 </div>
 {% endblock %}
 
-{% block scripts %}
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const lang = { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' };
-  if (document.getElementById('archiveFamiliesTable')) {
-    new DataTable('#archiveFamiliesTable', { language: lang });
-  }
-  if (document.getElementById('archivePersonsTable')) {
-    new DataTable('#archivePersonsTable', { language: lang });
-  }
-});
-</script>
-{% endblock %}
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,6 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
   <!-- DataTables -->
   <link rel="stylesheet" href="https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/2.0.8/css/dataTables.bootstrap5.min.css">
   <!-- Chart.js + datalabels plugin -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0"></script>
@@ -73,8 +72,8 @@
 </footer>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.datatables.net/2.0.8/js/dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/2.0.8/js/dataTables.bootstrap5.min.js"></script>
+<script defer src="https://cdn.datatables.net/2.0.8/js/dataTables.min.js"></script>
+<script defer src="{{ url_for('static', filename='js/tables.js') }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const styles = getComputedStyle(document.documentElement);

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -194,7 +194,7 @@
     <span class="badge rounded-pill badge-soft">{{ families|length }} familles</span>
   </div>
   <div class="table-responsive mt-3" style="max-height: 420px;">
-    <table id="dashboardFamiliesTable" class="table table-hover align-middle table-sm">
+    <table id="familiesTable" class="table table-striped table-hover align-middle table-sm">
       <thead>
         <tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th><th>Personnes</th><th></th></tr>
       </thead>
@@ -203,8 +203,8 @@
         <tr>
           <td class="text-secondary">{{ f.id }}</td>
           <td class="fw-semibold">{{ f.label or "—" }}</td>
-          <td>{{ rooms_text(f) or "—" }}</td>
-          <td data-order="{{ f.arrival_date.isoformat() if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or "—" }}</td>
+          <td data-order="{{ (rooms_text(f) or '')|int }}">{{ rooms_text(f) or "—" }}</td>
+          <td data-order="{{ f.arrival_date.strftime('%Y-%m-%d') if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or "—" }}</td>
           <td><span class="badge text-bg-secondary">{{ f.persons.count() }}</span></td>
           <td class="text-end">
             <a class="btn btn-sm btn-outline-info" href="{{ url_for('persons_list', fid=f.id) }}"><i class="bi bi-arrow-right-circle"></i></a>
@@ -321,8 +321,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }));
 
-  const lang = { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' };
-  new DataTable('#dashboardFamiliesTable', { language: lang });
 });
 </script>
 {% endblock %}

--- a/templates/families.html
+++ b/templates/families.html
@@ -38,15 +38,15 @@
   </div>
 
   <div class="table-responsive mt-3" style="max-height: 60vh;">
-    <table id="familiesTable" class="table table-hover table-sm align-middle">
+    <table id="familiesTable" class="table table-striped table-hover table-sm align-middle">
       <thead><tr><th>#</th><th>Label</th><th>Chambre</th><th>Arrivée</th><th>Personnes</th><th class="text-end">Actions</th></tr></thead>
       <tbody>
       {% for f in families %}
         <tr>
           <td class="text-secondary">{{ f.id }}</td>
           <td class="fw-semibold">{{ f.label or "—" }}</td>
-          <td>{{ rooms_text(f) or "—" }}</td>
-          <td data-order="{{ f.arrival_date.isoformat() if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or "—" }}</td>
+          <td data-order="{{ (rooms_text(f) or '')|int }}">{{ rooms_text(f) or "—" }}</td>
+          <td data-order="{{ f.arrival_date.strftime('%Y-%m-%d') if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or "—" }}</td>
           <td><span class="badge text-bg-secondary">{{ f.persons.count() }}</span></td>
           <td class="text-end">
             <button class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#famModal{{ f.id }}"><i class="bi bi-eye"></i></button>
@@ -88,13 +88,4 @@
 {% endfor %}
 {% endblock %}
 
-{% block scripts %}
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  new DataTable('#familiesTable', {
-    columnDefs: [{ orderable: false, targets: [5] }],
-    language: { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' }
-  });
-});
-</script>
-{% endblock %}
+

--- a/templates/persons.html
+++ b/templates/persons.html
@@ -11,18 +11,18 @@
 
 <div class="card shadow-soft p-3">
   <div class="table-responsive">
-    <table id="personsTable" class="table table-hover table-sm align-middle">
+    <table id="personsTable" class="table table-striped table-hover table-sm align-middle">
       <thead>
         <tr>
           <th>#</th>
           <th>Nom</th>
           <th>Prénom</th>
+          <th>Chambre</th>
+          <th>Arrivée</th>
           <th>Naissance</th>
           <th>Sexe</th>
           <th>Âge</th>
           <th class="text-end">Actions</th>
-          <th>Chambre</th>
-          <th>Arrivée</th>
         </tr>
       </thead>
       <tbody>
@@ -31,17 +31,18 @@
           <td class="text-secondary">{{ p.id }}</td>
           <td class="fw-semibold">{{ p.last_name }}</td>
           <td>{{ p.first_name }}</td>
-          <td data-order="{{ p.dob.isoformat() if p.dob else '' }}">{{ fmt_date(p.dob) or "—" }}</td>
+          <td data-order="{{ (rooms_text(family) or '')|int }}">{{ rooms_text(family) or "—" }}</td>
+          <td data-order="{{ family.arrival_date.strftime('%Y-%m-%d') if family.arrival_date else '' }}">{{ fmt_date(family.arrival_date) or "—" }}</td>
+          <td data-order="{{ p.dob.strftime('%Y-%m-%d') if p.dob else '' }}">{{ fmt_date(p.dob) or "—" }}</td>
           <td>{{ p.sex or "—" }}</td>
-          <td>{{ p.age if p.age is not none else "—" }}</td>
+          {% set age_days = ((now().date() - p.dob).days) if p.dob else -1 %}
+          <td data-order="{{ age_days }}">{{ p.age if p.age is not none else "—" }}</td>
           <td class="text-end">
             <a class="btn btn-sm btn-outline-warning" href="{{ url_for('persons_edit', fid=family.id, pid=p.id) }}"><i class="bi bi-pencil"></i></a>
             <form method="post" action="{{ url_for('persons_delete', fid=family.id, pid=p.id) }}" class="d-inline" onsubmit="return confirm('Supprimer cette personne ?');">
               <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash3"></i></button>
             </form>
           </td>
-          <td>{{ rooms_text(family) or "—" }}</td>
-          <td data-order="{{ family.arrival_date.isoformat() if family.arrival_date else '' }}">{{ fmt_date(family.arrival_date) or "—" }}</td>
         </tr>
       {% endfor %}
       </tbody>
@@ -50,18 +51,4 @@
 </div>
 {% endblock %}
 
-{% block scripts %}
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  new DataTable('#personsTable', {
-    columnDefs: [
-      { orderable: false, targets: [0,6,7,8] },
-      { visible: false, targets: [7,8] }
-    ],
-    language: {
-      url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json'
-    }
-  });
-});
-</script>
-{% endblock %}
+

--- a/templates/residents.html
+++ b/templates/residents.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="card shadow-soft p-3">
   <div class="table-responsive">
-    <table id="residentsTable" class="table table-hover table-sm align-middle">
+    <table id="personsTable" class="table table-striped table-hover table-sm align-middle">
       <thead>
         <tr>
           <th>#</th>
@@ -23,10 +23,10 @@
           <td class="fw-semibold">{{ p.last_name }}</td>
           <td>{{ p.first_name }}</td>
           <td>{{ p.sex or "—" }}</td>
-          <td>{{ p.age if p.age is not none else "—" }}</td>
+          <td data-order="{{ p.age if p.age is not none else -1 }}">{{ p.age if p.age is not none else "—" }}</td>
           <td>{{ p.family_label or "—" }}</td>
-          <td>{{ p.room_number or "—" }}</td>
-          <td data-order="{{ p.arrival_date.isoformat() if p.arrival_date else '' }}">{{ fmt_date(p.arrival_date) or "—" }}</td>
+          <td data-order="{{ p.room_number|int if p.room_number else '' }}">{{ p.room_number or "—" }}</td>
+          <td data-order="{{ p.arrival_date.strftime('%Y-%m-%d') if p.arrival_date else '' }}">{{ fmt_date(p.arrival_date) or "—" }}</td>
         </tr>
       {% endfor %}
       </tbody>
@@ -34,12 +34,4 @@
   </div>
 </div>
 {% endblock %}
-{% block scripts %}
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  new DataTable('#residentsTable', {
-    language: { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' }
-  });
-});
-</script>
-{% endblock %}
+

--- a/templates/search.html
+++ b/templates/search.html
@@ -44,15 +44,15 @@
       </form>
       {% if families %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table id="searchFamiliesTable" class="table table-sm table-hover align-middle">
+        <table id="familiesTable" class="table table-striped table-hover table-sm align-middle">
           <thead><tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th></tr></thead>
           <tbody>
           {% for f in families %}
             <tr>
               <td class="text-secondary">{{ f.id }}</td>
               <td>{{ f.label or '—' }}</td>
-              <td>{{ rooms_text(f) or '—' }}</td>
-              <td data-order="{{ f.arrival_date.isoformat() if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or '—' }}</td>
+              <td data-order="{{ (rooms_text(f) or '')|int }}">{{ rooms_text(f) or '—' }}</td>
+              <td data-order="{{ f.arrival_date.strftime('%Y-%m-%d') if f.arrival_date else '' }}">{{ fmt_date(f.arrival_date) or '—' }}</td>
             </tr>
           {% endfor %}
           </tbody>
@@ -102,7 +102,7 @@
       </form>
       {% if persons %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table id="searchPersonsTable" class="table table-sm table-hover align-middle">
+        <table id="personsTable" class="table table-striped table-hover table-sm align-middle">
           <thead><tr><th>#</th><th>Nom</th><th>Prénom</th><th>Âge</th><th>Chambre</th><th>Arrivée</th></tr></thead>
           <tbody>
           {% for p in persons %}
@@ -110,9 +110,9 @@
               <td class="text-secondary">{{ p.id }}</td>
               <td>{{ p.last_name }}</td>
               <td>{{ p.first_name }}</td>
-              <td>{{ p.age if p.age is not none else '—' }}</td>
-              <td>{{ p.room_number or '—' }}</td>
-              <td data-order="{{ p.arrival_date.isoformat() if p.arrival_date else '' }}">{{ fmt_date(p.arrival_date) or '—' }}</td>
+              <td data-order="{{ p.age if p.age is not none else -1 }}">{{ p.age if p.age is not none else '—' }}</td>
+              <td data-order="{{ p.room_number|int if p.room_number else '' }}">{{ p.room_number or '—' }}</td>
+              <td data-order="{{ p.arrival_date.strftime('%Y-%m-%d') if p.arrival_date else '' }}">{{ fmt_date(p.arrival_date) or '—' }}</td>
             </tr>
           {% endfor %}
           </tbody>
@@ -124,16 +124,4 @@
 </div>
 {% endblock %}
 
-{% block scripts %}
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  const lang = { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' };
-  if (document.getElementById('searchFamiliesTable')) {
-    new DataTable('#searchFamiliesTable', { language: lang });
-  }
-  if (document.getElementById('searchPersonsTable')) {
-    new DataTable('#searchPersonsTable', { language: lang });
-  }
-});
-</script>
-{% endblock %}
+


### PR DESCRIPTION
## Résumé
- unifie le chargement de DataTables v2 avec scripts différés
- centralise l'initialisation des tableaux et harmonise les identifiants
- ajoute les attributs `data-order` pour trier chambres, dates et âges

## Validation
- [x] Tri par nom
- [x] Tri par numéro de chambre
- [x] Tri par date d’arrivée
- [x] Tri par date de naissance
- [x] Tri par âge

------
https://chatgpt.com/codex/tasks/task_e_68a9cfa953ac832496753ef3c73235c5