### PR TITLE
Corrige le tri et l'affichage de l'âge

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,6 +81,23 @@ def age_years(dob: date | None, ref: date | None = None) -> int | None:
     ref = ref or date.today()
     return relativedelta(ref, dob).years
 
+def age_days(dob: date | None, ref: date | None = None) -> int:
+    if not dob:
+        return -1
+    ref = ref or date.today()
+    return (ref - dob).days
+
+def age_text(dob: date | None, ref: date | None = None) -> str:
+    if not dob:
+        return ""
+    ref = ref or date.today()
+    rd = relativedelta(ref, dob)
+    if rd.years >= 1:
+        return f"{rd.years} an{'s' if rd.years > 1 else ''}"
+    if rd.months >= 1:
+        return f"{rd.months} mois"
+    return f"{rd.days} jour{'s' if rd.days > 1 else ''}"
+
 def bucket_for_age(a: int | None):
     if a is None:
         return None
@@ -99,6 +116,7 @@ def inject_globals():
         "sex_choices": SEX_CHOICES,
         "theme": request.cookies.get("theme", "dark"),
         "age_years": age_years,
+        "age_text": age_text,
         "rooms_text": rooms_text,
     }
 
@@ -379,7 +397,9 @@ def persons_list(fid):
             "last_name": p.last_name,
             "dob": p.dob,
             "sex": p.sex,
-            "age": age_years(p.dob, today)
+            "age": age_years(p.dob, today),
+            "age_text": age_text(p.dob, today),
+            "age_days": age_days(p.dob, today)
         })
     return render_template("persons.html", family=fam, persons=rows)
 
@@ -433,6 +453,8 @@ def residents_list():
             "last_name": p.last_name,
             "sex": p.sex,
             "age": age_years(p.dob, today),
+            "age_text": age_text(p.dob, today),
+            "age_days": age_days(p.dob, today),
             "family_label": fam.label,
             "room_number": rooms_text(fam),
             "arrival_date": fam.arrival_date,
@@ -490,6 +512,8 @@ def search():
                 "first_name": p.first_name,
                 "last_name": p.last_name,
                 "age": age_years(p.dob, today),
+                "age_text": age_text(p.dob, today),
+                "age_days": age_days(p.dob, today),
                 "room_number": rooms_text(p.family),
                 "arrival_date": p.family.arrival_date,
             }
@@ -561,6 +585,8 @@ def archive():
                 "first_name": p.first_name,
                 "last_name": p.last_name,
                 "age": age_years(p.dob, today),
+                "age_text": age_text(p.dob, today),
+                "age_days": age_days(p.dob, today),
                 "room_number": rooms_text(p.family),
                 "arrival_date": p.family.arrival_date,
             }

--- a/static/js/tables.js
+++ b/static/js/tables.js
@@ -7,9 +7,11 @@ document.addEventListener('DOMContentLoaded', () => {
     ordering: true,
     order: [],
     language: { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' },
-    columnDefs: [{ targets: -1, orderable: false }]
+    columnDefs: [{ targets: 'no-sort', orderable: false }]
   };
-  if (document.querySelector('#personsTable')) new DataTable('#personsTable', opts);
-  if (document.querySelector('#familiesTable')) new DataTable('#familiesTable', opts);
+  const pt = document.querySelector('#personsTable');
+  if (pt) new DataTable(pt, opts);
+  const ft = document.querySelector('#familiesTable');
+  if (ft) new DataTable(ft, opts);
 });
 

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -115,8 +115,7 @@
               <td class="text-secondary">{{ p.id }}</td>
               <td>{{ p.last_name }}</td>
               <td>{{ p.first_name }}</td>
-              {% set age_jours = ((now().date() - p.dob).days) if p.dob else -1 %}
-              <td data-order="{{ age_jours }}">{{ p.age_affiche or '' }}</td>
+                <td data-order="{{ p.age_days }}">{{ p.age_text or '' }}</td>
               <td data-order="{{ (p.room_number or 0)|int }}">{{ p.room_number or '' }}</td>
               <td data-order="{{ p.arrival_date.strftime('%Y-%m-%d') if p.arrival_date }}">
                 {{ p.arrival_date.strftime('%d/%m/%Y') if p.arrival_date }}

--- a/templates/families.html
+++ b/templates/families.html
@@ -39,7 +39,7 @@
 
   <div class="table-responsive mt-3" style="max-height: 60vh;">
     <table id="familiesTable" class="table table-striped table-hover table-sm align-middle">
-      <thead><tr><th>#</th><th>Label</th><th>Chambre</th><th>Arrivée</th><th>Personnes</th><th class="text-end">Actions</th></tr></thead>
+      <thead><tr><th>#</th><th>Label</th><th>Chambre</th><th>Arrivée</th><th>Personnes</th><th class="no-sort text-end">Actions</th></tr></thead>
       <tbody>
       {% for f in families %}
         <tr>

--- a/templates/persons.html
+++ b/templates/persons.html
@@ -22,7 +22,7 @@
           <th>Naissance</th>
           <th>Sexe</th>
           <th>Âge</th>
-          <th class="text-end">Actions</th>
+            <th class="no-sort text-end">Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -39,8 +39,7 @@
             {{ p.dob.strftime('%d/%m/%Y') if p.dob }}
           </td>
           <td>{{ p.sex or '' }}</td>
-          {% set age_jours = ((now().date() - p.dob).days) if p.dob else -1 %}
-          <td data-order="{{ age_jours }}">{{ p.age_affiche or '' }}</td>
+            <td data-order="{{ p.age_days }}">{{ p.age_text or '' }}</td>
           <td class="text-end">
             <a class="btn btn-sm btn-outline-warning" href="{{ url_for('persons_edit', fid=family.id, pid=p.id) }}"><i class="bi bi-pencil"></i></a>
             <form method="post" action="{{ url_for('persons_delete', fid=family.id, pid=p.id) }}" class="d-inline" onsubmit="return confirm('Supprimer cette personne ?');">

--- a/templates/residents.html
+++ b/templates/residents.html
@@ -23,8 +23,7 @@
           <td class="fw-semibold">{{ p.last_name }}</td>
           <td>{{ p.first_name }}</td>
           <td>{{ p.sex or '' }}</td>
-          {% set age_jours = ((now().date() - p.dob).days) if p.dob else -1 %}
-          <td data-order="{{ age_jours }}">{{ p.age_affiche or '' }}</td>
+            <td data-order="{{ p.age_days }}">{{ p.age_text or '' }}</td>
           <td>{{ p.family_label or '' }}</td>
           <td data-order="{{ (p.room_number or 0)|int }}">{{ p.room_number or '' }}</td>
           <td data-order="{{ p.arrival_date.strftime('%Y-%m-%d') if p.arrival_date }}">

--- a/templates/search.html
+++ b/templates/search.html
@@ -112,8 +112,7 @@
               <td class="text-secondary">{{ p.id }}</td>
               <td>{{ p.last_name }}</td>
               <td>{{ p.first_name }}</td>
-              {% set age_jours = ((now().date() - p.dob).days) if p.dob else -1 %}
-              <td data-order="{{ age_jours }}">{{ p.age_affiche or '' }}</td>
+              <td data-order="{{ p.age_days }}">{{ p.age_text or '' }}</td>
               <td data-order="{{ (p.room_number or 0)|int }}">{{ p.room_number or '' }}</td>
               <td data-order="{{ p.arrival_date.strftime('%Y-%m-%d') if p.arrival_date }}">
                 {{ p.arrival_date.strftime('%d/%m/%Y') if p.arrival_date }}


### PR DESCRIPTION
## Résumé
- Active le tri des tableaux DataTables et ignore les colonnes d'actions.
- Affiche l'âge des enfants en mois ou en jours lorsqu'il est inférieur à un an.

## Tests
- `python -m py_compile app.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68a9dba950d083249c707bb27be901c3