### PR TITLE
Initialisation générique des tableaux triables

### DIFF
--- a/static/js/tables.js
+++ b/static/js/tables.js
@@ -9,9 +9,8 @@ document.addEventListener('DOMContentLoaded', () => {
     language: { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' },
     columnDefs: [{ targets: 'no-sort', orderable: false }]
   };
-  const pt = document.querySelector('#personsTable');
-  if (pt) new DataTable(pt, opts);
-  const ft = document.querySelector('#familiesTable');
-  if (ft) new DataTable(ft, opts);
+  document.querySelectorAll('.sortable-table').forEach(table => {
+    new DataTable(table, opts);
+  });
 });
 

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -44,7 +44,7 @@
       </form>
       {% if families %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table id="familiesTable" class="table table-striped table-hover table-sm align-middle">
+        <table id="familiesTable" class="table table-striped table-hover table-sm align-middle sortable-table">
           <thead><tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th><th>Départ</th></tr></thead>
           <tbody>
           {% for f in families %}
@@ -107,7 +107,7 @@
       </form>
       {% if persons %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table id="personsTable" class="table table-striped table-hover table-sm align-middle">
+        <table id="personsTable" class="table table-striped table-hover table-sm align-middle sortable-table">
           <thead><tr><th>#</th><th>Nom</th><th>Prénom</th><th>Âge</th><th>Chambre</th><th>Arrivée</th></tr></thead>
           <tbody>
           {% for p in persons %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -194,7 +194,7 @@
     <span class="badge rounded-pill badge-soft">{{ families|length }} familles</span>
   </div>
   <div class="table-responsive mt-3" style="max-height: 420px;">
-    <table id="familiesTable" class="table table-striped table-hover align-middle table-sm">
+    <table id="familiesTable" class="table table-striped table-hover align-middle table-sm sortable-table">
       <thead>
         <tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th><th>Personnes</th><th></th></tr>
       </thead>

--- a/templates/families.html
+++ b/templates/families.html
@@ -38,7 +38,7 @@
   </div>
 
   <div class="table-responsive mt-3" style="max-height: 60vh;">
-    <table id="familiesTable" class="table table-striped table-hover table-sm align-middle">
+    <table id="familiesTable" class="table table-striped table-hover table-sm align-middle sortable-table">
       <thead><tr><th>#</th><th>Label</th><th>Chambre</th><th>Arrivée</th><th>Personnes</th><th class="no-sort text-end">Actions</th></tr></thead>
       <tbody>
       {% for f in families %}

--- a/templates/persons.html
+++ b/templates/persons.html
@@ -11,7 +11,7 @@
 
 <div class="card shadow-soft p-3">
   <div class="table-responsive">
-    <table id="personsTable" class="table table-striped table-hover table-sm align-middle">
+    <table id="personsTable" class="table table-striped table-hover table-sm align-middle sortable-table">
       <thead>
         <tr>
           <th>#</th>

--- a/templates/residents.html
+++ b/templates/residents.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="card shadow-soft p-3">
   <div class="table-responsive">
-    <table id="personsTable" class="table table-striped table-hover table-sm align-middle">
+    <table id="personsTable" class="table table-striped table-hover table-sm align-middle sortable-table">
       <thead>
         <tr>
           <th>#</th>

--- a/templates/search.html
+++ b/templates/search.html
@@ -44,7 +44,7 @@
       </form>
       {% if families %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table id="familiesTable" class="table table-striped table-hover table-sm align-middle">
+        <table id="familiesTable" class="table table-striped table-hover table-sm align-middle sortable-table">
           <thead><tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th></tr></thead>
           <tbody>
           {% for f in families %}
@@ -104,7 +104,7 @@
       </form>
       {% if persons %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table id="personsTable" class="table table-striped table-hover table-sm align-middle">
+        <table id="personsTable" class="table table-striped table-hover table-sm align-middle sortable-table">
           <thead><tr><th>#</th><th>Nom</th><th>Prénom</th><th>Âge</th><th>Chambre</th><th>Arrivée</th></tr></thead>
           <tbody>
           {% for p in persons %}


### PR DESCRIPTION
## Résumé
- remplace les sélections spécifiques des tableaux par une initialisation DataTables basée sur la classe `sortable-table`
- ajoute la classe `sortable-table` à tous les gabarits affichant des listes triables

## Tests
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python app.py` (démarrage et arrêt immédiat du serveur)


------
https://chatgpt.com/codex/tasks/task_e_68a9e03f357c8324a951e2c4023163c6