### PR TITLE
Uniformiser l'initialisation des tableaux

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ window.activeCharts.push(new Chart(document.getElementById('sexChart'), {
 Les tableaux des familles et des personnes s’appuient sur **DataTables** pour offrir un tri et une recherche instantanés.
 
 ```javascript
-new DataTable('#personsTable', {
+document.querySelectorAll('.sortable-table').forEach(t => new DataTable(t, {
   columnDefs: [
     { orderable: false, targets: [0,5,6,7,8] },
     { visible: false, targets: [7,8] }
   ],
   language: { url: 'https://cdn.datatables.net/plug-ins/2.0.8/i18n/fr-FR.json' }
-});
+}));
 ```
 
 ### 🎨 Sélecteur de thème

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -44,7 +44,7 @@
       </form>
       {% if families %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table id="familiesTable" class="table table-striped table-hover table-sm align-middle sortable-table">
+        <table class="table table-striped table-hover table-sm align-middle sortable-table">
           <thead><tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th><th>Départ</th></tr></thead>
           <tbody>
           {% for f in families %}
@@ -107,7 +107,7 @@
       </form>
       {% if persons %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table id="personsTable" class="table table-striped table-hover table-sm align-middle sortable-table">
+        <table class="table table-striped table-hover table-sm align-middle sortable-table">
           <thead><tr><th>#</th><th>Nom</th><th>Prénom</th><th>Âge</th><th>Chambre</th><th>Arrivée</th></tr></thead>
           <tbody>
           {% for p in persons %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -194,7 +194,7 @@
     <span class="badge rounded-pill badge-soft">{{ families|length }} familles</span>
   </div>
   <div class="table-responsive mt-3" style="max-height: 420px;">
-    <table id="familiesTable" class="table table-striped table-hover align-middle table-sm sortable-table">
+    <table class="table table-striped table-hover align-middle table-sm sortable-table">
       <thead>
         <tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th><th>Personnes</th><th></th></tr>
       </thead>

--- a/templates/families.html
+++ b/templates/families.html
@@ -38,7 +38,7 @@
   </div>
 
   <div class="table-responsive mt-3" style="max-height: 60vh;">
-    <table id="familiesTable" class="table table-striped table-hover table-sm align-middle sortable-table">
+    <table class="table table-striped table-hover table-sm align-middle sortable-table">
       <thead><tr><th>#</th><th>Label</th><th>Chambre</th><th>Arrivée</th><th>Personnes</th><th class="no-sort text-end">Actions</th></tr></thead>
       <tbody>
       {% for f in families %}

--- a/templates/persons.html
+++ b/templates/persons.html
@@ -11,7 +11,7 @@
 
 <div class="card shadow-soft p-3">
   <div class="table-responsive">
-    <table id="personsTable" class="table table-striped table-hover table-sm align-middle sortable-table">
+    <table class="table table-striped table-hover table-sm align-middle sortable-table">
       <thead>
         <tr>
           <th>#</th>

--- a/templates/residents.html
+++ b/templates/residents.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="card shadow-soft p-3">
   <div class="table-responsive">
-    <table id="personsTable" class="table table-striped table-hover table-sm align-middle sortable-table">
+    <table class="table table-striped table-hover table-sm align-middle sortable-table">
       <thead>
         <tr>
           <th>#</th>

--- a/templates/search.html
+++ b/templates/search.html
@@ -44,7 +44,7 @@
       </form>
       {% if families %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table id="familiesTable" class="table table-striped table-hover table-sm align-middle sortable-table">
+        <table class="table table-striped table-hover table-sm align-middle sortable-table">
           <thead><tr><th>#</th><th>Famille</th><th>Chambre</th><th>Arrivée</th></tr></thead>
           <tbody>
           {% for f in families %}
@@ -104,7 +104,7 @@
       </form>
       {% if persons %}
       <div class="table-responsive" style="max-height:40vh;">
-        <table id="personsTable" class="table table-striped table-hover table-sm align-middle sortable-table">
+        <table class="table table-striped table-hover table-sm align-middle sortable-table">
           <thead><tr><th>#</th><th>Nom</th><th>Prénom</th><th>Âge</th><th>Chambre</th><th>Arrivée</th></tr></thead>
           <tbody>
           {% for p in persons %}


### PR DESCRIPTION
## Résumé
- enlever les identifiants `familiesTable` et `personsTable` au profit de la classe commune `sortable-table`
- mettre à jour la documentation pour illustrer l’usage de cette classe

## Tests
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a9e37f21608324a785810679b8652a