### PR TITLE
Ajout de sous-onglets d'ancienneté pour familles, adultes et enfants

### DIFF
--- a/app.py
+++ b/app.py
@@ -149,6 +149,7 @@ def dashboard():
         s = p.sex if p.sex in sex_counts else "Autre/NP"
         sex_counts[s] += 1
         a = age_years(p.dob, today)
+        p._age = a
         b = bucket_for_age(a)
         if b and s in ("F", "M"):
             age_counts[b][s] += 1
@@ -163,6 +164,14 @@ def dashboard():
                     adult_female_count += 1
                 else:
                     adult_male_count += 1
+
+    # Listes des 5 adultes/enfants les plus âgés et les plus jeunes
+    adults = [p for p in persons if p._age is not None and p._age >= 18]
+    children = [p for p in persons if p._age is not None and p._age < 18]
+    oldest_adults = sorted(adults, key=lambda p: p._age, reverse=True)[:5]
+    youngest_adults = sorted(adults, key=lambda p: p._age)[:5]
+    oldest_children = sorted(children, key=lambda p: p._age, reverse=True)[:5]
+    youngest_children = sorted(children, key=lambda p: p._age)[:5]
 
     # Anniversaires (semaine/mois passés et à venir)
     birthdays_today: list[dict] = []
@@ -296,6 +305,10 @@ def dashboard():
         recent_labels=recent_labels,
         recent_values=recent_values,
         recent_tenures=recent_tenures,
+        oldest_adults=oldest_adults,
+        youngest_adults=youngest_adults,
+        oldest_children=oldest_children,
+        youngest_children=youngest_children,
         families=families,
         birthdays_today=birthdays_today,
         birthdays_week_ahead=birthdays_week_ahead,

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -70,18 +70,96 @@
       <h6 class="mb-3"><i class="bi bi-hourglass-split me-2"></i>Ancienneté</h6>
       <ul class="nav nav-pills mb-3" id="seniorityTab" role="tablist">
         <li class="nav-item" role="presentation">
-          <button class="nav-link active" id="old-tab" data-bs-toggle="pill" data-bs-target="#old-fam" type="button" role="tab">Plus anciennes</button>
+          <button class="nav-link active" id="old-tab" data-bs-toggle="pill" data-bs-target="#old" type="button" role="tab">Plus anciennes</button>
         </li>
         <li class="nav-item" role="presentation">
-          <button class="nav-link" id="new-tab" data-bs-toggle="pill" data-bs-target="#new-fam" type="button" role="tab">Plus récentes</button>
+          <button class="nav-link" id="new-tab" data-bs-toggle="pill" data-bs-target="#new" type="button" role="tab">Plus récentes</button>
         </li>
       </ul>
       <div class="tab-content">
-        <div class="tab-pane fade show active" id="old-fam" role="tabpanel">
-          <canvas id="oldFamiliesChart" height="200"></canvas>
+        <div class="tab-pane fade show active" id="old" role="tabpanel">
+          <ul class="nav nav-tabs small mb-3" id="oldSubTab" role="tablist">
+            <li class="nav-item" role="presentation">
+              <button class="nav-link active" id="old-fam-tab" data-bs-toggle="tab" data-bs-target="#old-fam" type="button" role="tab">Familles</button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button class="nav-link" id="old-adult-tab" data-bs-toggle="tab" data-bs-target="#old-adults" type="button" role="tab">Adultes</button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button class="nav-link" id="old-child-tab" data-bs-toggle="tab" data-bs-target="#old-children" type="button" role="tab">Enfants</button>
+            </li>
+          </ul>
+          <div class="tab-content">
+            <div class="tab-pane fade show active" id="old-fam" role="tabpanel">
+              <canvas id="oldFamiliesChart" height="200"></canvas>
+            </div>
+            <div class="tab-pane fade" id="old-adults" role="tabpanel">
+              <ul class="list-group list-group-flush small">
+                {% for p in oldest_adults %}
+                  <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>{{ p.first_name }} {{ p.last_name }} — chambre {{ rooms_text(p.family) }}</span>
+                    <span class="badge text-bg-primary rounded-pill">{{ age_years(p.dob) }} ans</span>
+                  </li>
+                {% else %}
+                  <li class="list-group-item">Aucun</li>
+                {% endfor %}
+              </ul>
+            </div>
+            <div class="tab-pane fade" id="old-children" role="tabpanel">
+              <ul class="list-group list-group-flush small">
+                {% for p in oldest_children %}
+                  <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>{{ p.first_name }} {{ p.last_name }} — chambre {{ rooms_text(p.family) }}</span>
+                    <span class="badge text-bg-primary rounded-pill">{{ age_years(p.dob) }} ans</span>
+                  </li>
+                {% else %}
+                  <li class="list-group-item">Aucun</li>
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
         </div>
-        <div class="tab-pane fade" id="new-fam" role="tabpanel">
-          <canvas id="newFamiliesChart" height="200"></canvas>
+        <div class="tab-pane fade" id="new" role="tabpanel">
+          <ul class="nav nav-tabs small mb-3" id="newSubTab" role="tablist">
+            <li class="nav-item" role="presentation">
+              <button class="nav-link active" id="new-fam-tab" data-bs-toggle="tab" data-bs-target="#new-fam" type="button" role="tab">Familles</button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button class="nav-link" id="new-adult-tab" data-bs-toggle="tab" data-bs-target="#new-adults" type="button" role="tab">Adultes</button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button class="nav-link" id="new-child-tab" data-bs-toggle="tab" data-bs-target="#new-children" type="button" role="tab">Enfants</button>
+            </li>
+          </ul>
+          <div class="tab-content">
+            <div class="tab-pane fade show active" id="new-fam" role="tabpanel">
+              <canvas id="newFamiliesChart" height="200"></canvas>
+            </div>
+            <div class="tab-pane fade" id="new-adults" role="tabpanel">
+              <ul class="list-group list-group-flush small">
+                {% for p in youngest_adults %}
+                  <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>{{ p.first_name }} {{ p.last_name }} — chambre {{ rooms_text(p.family) }}</span>
+                    <span class="badge text-bg-success rounded-pill">{{ age_years(p.dob) }} ans</span>
+                  </li>
+                {% else %}
+                  <li class="list-group-item">Aucun</li>
+                {% endfor %}
+              </ul>
+            </div>
+            <div class="tab-pane fade" id="new-children" role="tabpanel">
+              <ul class="list-group list-group-flush small">
+                {% for p in youngest_children %}
+                  <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>{{ p.first_name }} {{ p.last_name }} — chambre {{ rooms_text(p.family) }}</span>
+                    <span class="badge text-bg-success rounded-pill">{{ age_years(p.dob) }} ans</span>
+                  </li>
+                {% else %}
+                  <li class="list-group-item">Aucun</li>
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Résumé
- Ajout du calcul et du passage au template des listes d'adultes et d'enfants les plus âgés et les plus jeunes.
- Refonte de la section "Ancienneté" avec des sous-onglets Familles/Adultes/Enfants pour les onglets Plus anciennes et Plus récentes.

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9ebd4ea948324b04750a1ddee8570