### PR TITLE
Trie des anniversaires par proximité

### DIFF
--- a/app.py
+++ b/app.py
@@ -240,6 +240,11 @@ def dashboard():
                 "age": age_years(p.dob, prev_bd),
             })
 
+    birthdays_week_ahead.sort(key=lambda b: b["date"])
+    birthdays_month_ahead.sort(key=lambda b: b["date"])
+    birthdays_week_past.sort(key=lambda b: b["date"], reverse=True)
+    birthdays_month_past.sort(key=lambda b: b["date"], reverse=True)
+
     # Familles récentes et ancienneté
     families = Family.query.filter(Family.departure_date.is_(None)).order_by(
         Family.arrival_date.desc().nullslast(), Family.id.desc()


### PR DESCRIPTION
## Résumé
- Trie les anniversaires à venir du plus proche au plus lointain.
- Trie les anniversaires passés du plus récent au plus ancien.

## Tests
- `python -m pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9f9afd4048324953e1cc12a975b53