### PR TITLE
Éviter l'affichage de 'None' pour les champs vides

### DIFF
--- a/app.py
+++ b/app.py
@@ -65,6 +65,13 @@ AGE_COLORS_M = ['#128193', '#19a078', '#208537', '#cc9a05', '#ca6410', '#b02a37'
 
 SEX_CHOICES = ["F", "M", "Autre/NP"]
 
+def clean_field(v: str | None) -> str | None:
+    """Retourne None pour les champs vides ou contenant la chaîne 'None'."""
+    if not v:
+        return None
+    v = v.strip()
+    return None if v.lower() == "none" or v == "" else v
+
 def parse_date(s: str | None):
     if not s:
         return None
@@ -112,10 +119,10 @@ def bucket_for_age(a: int | None):
     return None
 
 def rooms_text(f: "Family") -> str:
-    return " & ".join(r for r in [f.room_number, f.room_number2] if r)
+    return " & ".join(r for r in [clean_field(f.room_number), clean_field(f.room_number2)] if r)
 
 def phones_text(f: "Family") -> str:
-    return " / ".join(p for p in [f.phone1, f.phone2] if p)
+    return " / ".join(p for p in [clean_field(f.phone1), clean_field(f.phone2)] if p)
 
 
 def age_color(p: "Person", age: int | None = None) -> str:
@@ -383,12 +390,12 @@ def families_list():
 def families_new():
     if request.method == "POST":
         f = Family(
-            label=request.form.get("label") or None,
-            room_number=request.form.get("room_number") or None,
-            room_number2=request.form.get("room_number2") or None,
+            label=clean_field(request.form.get("label")),
+            room_number=clean_field(request.form.get("room_number")),
+            room_number2=clean_field(request.form.get("room_number2")),
             arrival_date=parse_date(request.form.get("arrival_date")),
-            phone1=request.form.get("phone1") or None,
-            phone2=request.form.get("phone2") or None,
+            phone1=clean_field(request.form.get("phone1")),
+            phone2=clean_field(request.form.get("phone2")),
         )
         db.session.add(f)
         db.session.commit()
@@ -399,12 +406,12 @@ def families_new():
 def families_edit(fid):
     fam = Family.query.get_or_404(fid)
     if request.method == "POST":
-        fam.label = request.form.get("label") or None
-        fam.room_number = request.form.get("room_number") or None
-        fam.room_number2 = request.form.get("room_number2") or None
+        fam.label = clean_field(request.form.get("label"))
+        fam.room_number = clean_field(request.form.get("room_number"))
+        fam.room_number2 = clean_field(request.form.get("room_number2"))
         fam.arrival_date = parse_date(request.form.get("arrival_date"))
-        fam.phone1 = request.form.get("phone1") or None
-        fam.phone2 = request.form.get("phone2") or None
+        fam.phone1 = clean_field(request.form.get("phone1"))
+        fam.phone2 = clean_field(request.form.get("phone2"))
         db.session.commit()
         return redirect(url_for("families_list"))
     return render_template("family_form.html", family=fam)
@@ -456,7 +463,7 @@ def persons_new(fid):
             last_name=request.form.get("last_name").strip(),
             dob=parse_date(request.form.get("dob")),
             sex=request.form.get("sex") or "Autre/NP",
-            phone=request.form.get("phone") or None,
+            phone=clean_field(request.form.get("phone")),
         )
         db.session.add(p)
         db.session.commit()
@@ -472,7 +479,7 @@ def persons_edit(fid, pid):
         p.last_name  = request.form.get("last_name").strip()
         p.dob = parse_date(request.form.get("dob"))
         p.sex = request.form.get("sex") or "Autre/NP"
-        p.phone = request.form.get("phone") or None
+        p.phone = clean_field(request.form.get("phone"))
         db.session.commit()
         return redirect(url_for("persons_list", fid=fid))
     return render_template("person_form.html", family=fam, person=p)

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -50,7 +50,7 @@
           {% for f in families %}
             <tr>
               <td class="text-secondary">{{ f.id }}</td>
-              <td>{{ f.label or '' }}</td>
+              <td>{{ '' if f.label in [None, 'None'] else f.label }}</td>
                 <td data-order="{{ (rooms_text(f) or 0)|int }}">{{ rooms_text(f) or '' }}</td>
                 <td>{{ phones_text(f) or '' }}</td>
                 <td data-order="{{ f.arrival_date.strftime('%Y-%m-%d') if f.arrival_date }}">
@@ -122,9 +122,9 @@
               <td class="text-secondary">{{ p.id }}</td>
               <td>{{ p.last_name }}</td>
                 <td>{{ p.first_name }}</td>
-                <td>{{ p.phone or '' }}</td>
+                <td>{{ '' if p.phone in [None, 'None'] else p.phone }}</td>
                 <td data-order="{{ p.age_days }}">{{ p.age_text or '' }}</td>
-                <td data-order="{{ (p.room_number or 0)|int }}">{{ p.room_number or '' }}</td>
+                <td data-order="{{ (p.room_number if p.room_number not in [None, 'None'] else 0)|int }}">{{ '' if p.room_number in [None, 'None'] else p.room_number }}</td>
                 <td data-order="{{ p.arrival_date.strftime('%Y-%m-%d') if p.arrival_date }}">
                   {{ p.arrival_date.strftime('%d/%m/%Y') if p.arrival_date }}
                 </td>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -25,7 +25,7 @@
             <div class="fw-bold">Familles &gt;3 pers. dans une chambre (hors 53/54)</div>
             <ul class="mb-0 ps-3">
               {% for f in overcrowded_families %}
-                <li class="small">{{ f.label or "Famille " ~ f.id }} — chambre {{ rooms_text(f) }} ({{ f.persons.count() }} pers.)</li>
+                <li class="small">{{ f.label if f.label not in [None, 'None'] else 'Famille ' ~ f.id }} — chambre {{ rooms_text(f) }} ({{ f.persons.count() }} pers.)</li>
               {% else %}
                 <li class="small">Aucune</li>
               {% endfor %}
@@ -290,7 +290,7 @@
       {% for f in families %}
         <tr>
           <td class="text-secondary">{{ f.id }}</td>
-          <td class="fw-semibold">{{ f.label or "—" }}</td>
+          <td class="fw-semibold">{{ f.label if f.label not in [None, 'None'] else '—' }}</td>
           <td data-order="{{ (rooms_text(f) or 0)|int }}">{{ rooms_text(f) or '' }}</td>
           <td>{{ phones_text(f) or '' }}</td>
           <td data-order="{{ f.arrival_date.strftime('%Y-%m-%d') if f.arrival_date }}">
@@ -312,7 +312,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">{{ f.label or 'Famille' }}</h5>
+        <h5 class="modal-title">{{ f.label if f.label not in [None, 'None'] else 'Famille' }}</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
@@ -322,7 +322,7 @@
         <hr>
         <ul class="list-unstyled mb-0">
           {% for p in f.persons.order_by(Person.id.asc()).all() %}
-          <li>{{ p.first_name }} {{ p.last_name }} – {{ age_years(p.dob) or '—' }} ans{% if p.phone %} – {{ p.phone }}{% endif %}</li>
+          <li>{{ p.first_name }} {{ p.last_name }} – {{ age_years(p.dob) or '—' }} ans{% if p.phone and p.phone != 'None' %} – {{ p.phone }}{% endif %}</li>
           {% endfor %}
         </ul>
       </div>

--- a/templates/families.html
+++ b/templates/families.html
@@ -44,7 +44,7 @@
       {% for f in families %}
         <tr>
           <td class="text-secondary">{{ f.id }}</td>
-          <td class="fw-semibold">{{ f.label or "—" }}</td>
+            <td class="fw-semibold">{{ f.label if f.label not in [None, 'None'] else '—' }}</td>
           <td data-order="{{ (rooms_text(f) or 0)|int }}">{{ rooms_text(f) or '' }}</td>
             <td>{{ phones_text(f) or '' }}</td>
             <td data-order="{{ f.arrival_date.strftime('%Y-%m-%d') if f.arrival_date }}">
@@ -72,7 +72,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">{{ f.label or 'Famille' }}</h5>
+        <h5 class="modal-title">{{ f.label if f.label not in [None, 'None'] else 'Famille' }}</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
       <div class="modal-body">
@@ -82,7 +82,7 @@
         <hr>
           <ul class="list-unstyled mb-0">
             {% for p in f.persons.order_by(Person.id.asc()).all() %}
-            <li>{{ p.first_name }} {{ p.last_name }} – {{ age_years(p.dob) or '—' }} ans{% if p.phone %} – {{ p.phone }}{% endif %}</li>
+              <li>{{ p.first_name }} {{ p.last_name }} – {{ age_years(p.dob) or '—' }} ans{% if p.phone and p.phone != 'None' %} – {{ p.phone }}{% endif %}</li>
             {% endfor %}
           </ul>
       </div>

--- a/templates/family_depart.html
+++ b/templates/family_depart.html
@@ -2,7 +2,7 @@
 {% block title %}Départ famille - Kardex Hôtel Social{% endblock %}
 {% block content %}
 <div class="card shadow-soft p-3">
-  <h4 class="mb-3">Départ : {{ family.label or 'Famille' }}</h4>
+<h4 class="mb-3">Départ : {{ family.label if family.label not in [None, 'None'] else 'Famille' }}</h4>
   <form method="post" class="row g-3">
     <div class="col-md-6">
       <div class="form-floating">

--- a/templates/family_form.html
+++ b/templates/family_form.html
@@ -6,19 +6,19 @@
   <form method="post" class="row g-3">
     <div class="col-md-4">
       <div class="form-floating">
-        <input name="label" class="form-control" id="fl1" placeholder="Label" value="{{ family.label if family else '' }}">
+        <input name="label" class="form-control" id="fl1" placeholder="Label" value="{{ family.label or '' if family else '' }}">
         <label for="fl1">Label (ex: Famille Dupont)</label>
       </div>
     </div>
     <div class="col-md-2">
       <div class="form-floating">
-        <input name="room_number" class="form-control" id="fl2" placeholder="Chambre" value="{{ family.room_number if family else '' }}">
+        <input name="room_number" class="form-control" id="fl2" placeholder="Chambre" value="{{ family.room_number or '' if family else '' }}">
         <label for="fl2">Chambre 1</label>
       </div>
     </div>
     <div class="col-md-2">
       <div class="form-floating">
-        <input name="room_number2" class="form-control" id="fl2b" placeholder="Chambre 2" value="{{ family.room_number2 if family else '' }}">
+        <input name="room_number2" class="form-control" id="fl2b" placeholder="Chambre 2" value="{{ family.room_number2 or '' if family else '' }}">
         <label for="fl2b">Chambre 2</label>
       </div>
     </div>
@@ -30,13 +30,13 @@
       </div>
       <div class="col-md-3">
         <div class="form-floating">
-          <input name="phone1" class="form-control" id="fl4" placeholder="Téléphone 1" value="{{ family.phone1 if family else '' }}">
+          <input name="phone1" class="form-control" id="fl4" placeholder="Téléphone 1" value="{{ family.phone1 or '' if family else '' }}">
           <label for="fl4">Téléphone 1</label>
         </div>
       </div>
       <div class="col-md-3">
         <div class="form-floating">
-          <input name="phone2" class="form-control" id="fl5" placeholder="Téléphone 2" value="{{ family.phone2 if family else '' }}">
+          <input name="phone2" class="form-control" id="fl5" placeholder="Téléphone 2" value="{{ family.phone2 or '' if family else '' }}">
           <label for="fl5">Téléphone 2</label>
         </div>
       </div>

--- a/templates/person_form.html
+++ b/templates/person_form.html
@@ -2,7 +2,7 @@
 {% block title %}Personne - Kardex Hôtel Social{% endblock %}
 {% block content %}
 <div class="card shadow-soft p-3">
-  <h4 class="mb-3">{{ 'Modifier' if person else 'Ajouter' }} une personne <span class="text-secondary">dans {{ family.label or 'Famille' }}</span></h4>
+<h4 class="mb-3">{{ 'Modifier' if person else 'Ajouter' }} une personne <span class="text-secondary">dans {{ family.label if family.label not in [None, 'None'] else 'Famille' }}</span></h4>
   <form method="post" class="row g-3">
     <div class="col-md-3">
       <div class="form-floating">
@@ -34,7 +34,7 @@
       </div>
       <div class="col-md-3">
         <div class="form-floating">
-          <input name="phone" class="form-control" id="p5" placeholder="Téléphone" value="{{ person.phone if person else '' }}">
+          <input name="phone" class="form-control" id="p5" placeholder="Téléphone" value="{{ person.phone or '' if person else '' }}">
           <label for="p5">Téléphone</label>
         </div>
       </div>

--- a/templates/persons.html
+++ b/templates/persons.html
@@ -2,7 +2,7 @@
 {% block title %}Personnes - Kardex Hôtel Social{% endblock %}
 {% block content %}
 <div class="d-flex align-items-center justify-content-between mb-3">
-  <h4 class="m-0"><i class="bi bi-person-lines-fill me-2"></i>{{ family.label or 'Famille' }} <span class="text-secondary">| Chambre {{ rooms_text(family) or '—' }}</span></h4>
+<h4 class="m-0"><i class="bi bi-person-lines-fill me-2"></i>{{ family.label if family.label not in [None, 'None'] else 'Famille' }} <span class="text-secondary">| Chambre {{ rooms_text(family) or '—' }}</span></h4>
   <div class="d-flex gap-2">
     <a class="btn btn-outline-secondary" href="{{ url_for('families_list') }}"><i class="bi bi-arrow-left"></i> Retour</a>
     <a class="btn btn-primary" href="{{ url_for('persons_new', fid=family.id) }}"><i class="bi bi-plus-lg me-1"></i>Ajouter une personne</a>
@@ -40,7 +40,7 @@
             {{ p.dob.strftime('%d/%m/%Y') if p.dob }}
           </td>
             <td>{{ p.sex or '' }}</td>
-            <td>{{ p.phone or '' }}</td>
+            <td>{{ '' if p.phone in [None, 'None'] else p.phone }}</td>
             <td data-order="{{ p.age_days }}">{{ p.age_text or '' }}</td>
           <td class="text-end">
             <a class="btn btn-sm btn-outline-warning" href="{{ url_for('persons_edit', fid=family.id, pid=p.id) }}"><i class="bi bi-pencil"></i></a>

--- a/templates/residents.html
+++ b/templates/residents.html
@@ -24,10 +24,10 @@
           <td class="fw-semibold">{{ p.last_name }}</td>
           <td>{{ p.first_name }}</td>
             <td>{{ p.sex or '' }}</td>
-            <td>{{ p.phone or '' }}</td>
+            <td>{{ '' if p.phone in [None, 'None'] else p.phone }}</td>
             <td data-order="{{ p.age_days }}">{{ p.age_text or '' }}</td>
-          <td>{{ p.family_label or '' }}</td>
-          <td data-order="{{ (p.room_number or 0)|int }}">{{ p.room_number or '' }}</td>
+            <td>{{ '' if p.family_label in [None, 'None'] else p.family_label }}</td>
+            <td data-order="{{ (p.room_number if p.room_number not in [None, 'None'] else 0)|int }}">{{ '' if p.room_number in [None, 'None'] else p.room_number }}</td>
           <td data-order="{{ p.arrival_date.strftime('%Y-%m-%d') if p.arrival_date }}">
             {{ p.arrival_date.strftime('%d/%m/%Y') if p.arrival_date }}
           </td>

--- a/templates/search.html
+++ b/templates/search.html
@@ -50,7 +50,7 @@
           {% for f in families %}
             <tr>
               <td class="text-secondary">{{ f.id }}</td>
-              <td>{{ f.label or '' }}</td>
+              <td>{{ '' if f.label in [None, 'None'] else f.label }}</td>
                 <td data-order="{{ (rooms_text(f) or 0)|int }}">{{ rooms_text(f) or '' }}</td>
                 <td>{{ phones_text(f) or '' }}</td>
                 <td data-order="{{ f.arrival_date.strftime('%Y-%m-%d') if f.arrival_date }}">
@@ -119,9 +119,9 @@
               <td class="text-secondary">{{ p.id }}</td>
               <td>{{ p.last_name }}</td>
                 <td>{{ p.first_name }}</td>
-                <td>{{ p.phone or '' }}</td>
+                <td>{{ '' if p.phone in [None, 'None'] else p.phone }}</td>
                 <td data-order="{{ p.age_days }}">{{ p.age_text or '' }}</td>
-                <td data-order="{{ (p.room_number or 0)|int }}">{{ p.room_number or '' }}</td>
+                <td data-order="{{ (p.room_number if p.room_number not in [None, 'None'] else 0)|int }}">{{ '' if p.room_number in [None, 'None'] else p.room_number }}</td>
                 <td data-order="{{ p.arrival_date.strftime('%Y-%m-%d') if p.arrival_date }}">
                   {{ p.arrival_date.strftime('%d/%m/%Y') if p.arrival_date }}
                 </td>


### PR DESCRIPTION
## Résumé
- Nettoyage des données saisies pour éviter l'enregistrement de la chaîne `None`.
- Mise à jour des formulaires et des listes afin que les champs vides restent vides.

## Test
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acbda91e288324ad500fc66049a0df