### PR TITLE
Place l'alerte des chambres disponibles en tête du tableau de bord

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -19,6 +19,21 @@
     <div class="card shadow-soft p-3 mt-4">
       <h6 class="mb-3"><i class="bi bi-exclamation-triangle me-2"></i>Alertes</h6>
       <div class="d-flex flex-column gap-3">
+        <div class="alert alert-success d-flex align-items-start mb-0" role="alert">
+          <i class="bi bi-door-open fs-4 me-2"></i>
+          <div>
+            <div class="fw-bold">Chambres disponibles</div>
+            {% if free_rooms %}
+            <div class="d-flex flex-wrap gap-2 mt-1">
+              {% for r in free_rooms %}
+                <span class="badge rounded-pill bg-success-subtle text-success border border-success-subtle">{{ r }}</span>
+              {% endfor %}
+            </div>
+            {% else %}
+              <div class="small">Aucune</div>
+            {% endif %}
+          </div>
+        </div>
         <div class="alert alert-danger d-flex align-items-start mb-0" role="alert">
           <i class="bi bi-people-fill fs-4 me-2"></i>
           <div>
@@ -64,21 +79,6 @@
                 <li class="small">Aucune</li>
               {% endfor %}
             </ul>
-          </div>
-        </div>
-        <div class="alert alert-success d-flex align-items-start mb-0" role="alert">
-          <i class="bi bi-door-open fs-4 me-2"></i>
-          <div>
-            <div class="fw-bold">Chambres disponibles</div>
-            {% if free_rooms %}
-            <div class="d-flex flex-wrap gap-2 mt-1">
-              {% for r in free_rooms %}
-                <span class="badge rounded-pill bg-success-subtle text-success border border-success-subtle">{{ r }}</span>
-              {% endfor %}
-            </div>
-            {% else %}
-              <div class="small">Aucune</div>
-            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Résumé
- Déplace l'alerte des chambres disponibles avant l'alerte pour les familles de plus de trois personnes

## Tests
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aff2ba5d0c8324b3c3ac6cd140fda2