### PR TITLE
Déplacement de la carte « Total clients » et correction des espacements

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,19 +4,6 @@
 <div class="row g-4">
   <div class="col-12 col-xl-4 d-flex flex-column">
     <div class="card shadow-soft p-3">
-      <div class="d-flex align-items-center">
-        <div class="display-6 me-3 text-info"><i class="bi bi-people-fill"></i></div>
-        <div>
-          <div class="text-secondary text-uppercase small">Total clients</div>
-          <div class="h3 m-0">{{ total_clients }}</div>
-          <div class="small text-secondary">
-            Adultes : {{ adult_female_count }} femmes, {{ adult_male_count }} hommes<br>
-            Enfants : {{ girl_count }} filles, {{ boy_count }} garçons
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="card shadow-soft p-3 mt-4">
       <h6 class="mb-3"><i class="bi bi-exclamation-triangle me-2"></i>Alertes</h6>
       <div class="d-flex flex-column gap-3">
         <div class="alert alert-success d-flex align-items-start mb-0" role="alert">
@@ -86,6 +73,19 @@
   </div>
   <div class="col-12 col-xl-4">
     <div class="card shadow-soft p-3">
+      <div class="d-flex align-items-center">
+        <div class="display-6 me-3 text-info"><i class="bi bi-people-fill"></i></div>
+        <div>
+          <div class="text-secondary text-uppercase small">Total clients</div>
+          <div class="h3 m-0">{{ total_clients }}</div>
+          <div class="small text-secondary">
+            Adultes : {{ adult_female_count }} femmes, {{ adult_male_count }} hommes<br>
+            Enfants : {{ girl_count }} filles, {{ boy_count }} garçons
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card shadow-soft p-3 mt-4">
       <h6 class="mb-3"><i class="bi bi-gender-ambiguous me-2"></i>Répartition par sexe</h6>
       <canvas id="sexChart" height="200"></canvas>
     </div>


### PR DESCRIPTION
## Résumé
- Place la carte **Total clients** dans la colonne centrale avant la carte "Répartition par sexe".
- Supprime la marge supérieure inutile de la carte **Alertes** et ajoute l'espacement requis dans la colonne centrale.

## Tests
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aff6af15388324a3c9d4b9b65f4855