### PR TITLE
Accès direct à la fiche famille depuis la disposition des chambres

### DIFF
--- a/app.py
+++ b/app.py
@@ -297,13 +297,13 @@ def dashboard():
                 occupied_rooms.add(r)
     free_rooms = sorted(all_rooms - occupied_rooms, key=int)
 
-    room_data = {r: {"occupied": False, "family": None} for r in all_rooms}
+    room_data = {r: {"occupied": False, "family": None, "family_id": None} for r in all_rooms}
     for f in families:
         fam_label = f.label if f.label not in [None, "None"] else f"Famille {f.id}"
         for r in (f.room_number, f.room_number2):
             r = clean_field(r)
             if r:
-                room_data[r] = {"occupied": True, "family": fam_label}
+                room_data[r] = {"occupied": True, "family": fam_label, "family_id": f.id}
 
     rdc_rooms = [str(n) for n in range(30, 55)]
     etage1_rooms = [str(n) for n in range(1, 30) if n != 13]

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -59,7 +59,10 @@
   </style>
   {% macro room_box(r) %}
     {% set info = room_data.get(r) %}
-    <div class="room-box border {{ 'bg-danger-subtle text-danger border-danger-subtle' if info and info.occupied else 'bg-success-subtle text-success border-success-subtle' }}" data-bs-toggle="tooltip" data-bs-title="{{ info.family if info and info.occupied else 'Libre' }}">{{ r }}</div>
+    <div class="room-box border {{ 'bg-danger-subtle text-danger border-danger-subtle' if info and info.occupied else 'bg-success-subtle text-success border-success-subtle' }}"
+         data-bs-toggle="tooltip"
+         data-bs-title="{{ info.family if info and info.occupied else 'Libre' }}"
+         {% if info and info.occupied %}data-family-id="{{ info.family_id }}"{% endif %}>{{ r }}</div>
   {% endmacro %}
   {% macro plain_box(label) %}
     <div class="room-box border plain-box">{{ label }}</div>
@@ -474,6 +477,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const roomTooltipTriggerList = document.querySelectorAll('#room-layout [data-bs-toggle="tooltip"]');
   roomTooltipTriggerList.forEach(el => new bootstrap.Tooltip(el));
+
+  const roomBoxes = document.querySelectorAll('#room-layout .room-box[data-family-id]');
+  roomBoxes.forEach(box => {
+    box.addEventListener('click', () => {
+      const modal = new bootstrap.Modal(document.getElementById(`famModal${box.dataset.familyId}`));
+      modal.show();
+    });
+  });
 
   window.activeCharts = [];
   window.activeCharts.push(new Chart(document.getElementById('sexChart'), {


### PR DESCRIPTION
## Résumé
- Ajoute l'identifiant de famille aux données de chambres
- Rend les chambres cliquables pour afficher la fiche simplifiée de la famille
- Ouvre la fiche correspondante via un modal Bootstrap

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0390f3ff8832493bc48a9265cebf2