### PR TITLE
Modernise l’affichage des alertes

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -91,11 +91,15 @@
 <i class="bi bi-people-fill fs-4 me-2"></i>
 <div>
 <div class="fw-bold">Familles &gt;3 pers. dans une chambre (hors 53/54)</div>
-<ul class="mb-0 ps-3">
+<ul class="list-group list-group-flush small mb-0">
               {% for f in overcrowded_families %}
-                <li class="small">{{ f.label if f.label not in [None, 'None'] else 'Famille ' ~ f.id }} — chambre {{ rooms_text(f) }} ({{ f.persons.count() }} pers.)</li>
+                <li class="list-group-item list-group-item-action px-2 d-flex flex-wrap align-items-center gap-2 border-0">
+                  <span class="fw-semibold">{{ f.label if f.label not in [None, 'None'] else 'Famille ' ~ f.id }}</span>
+                  <span class="text-secondary">chambre {{ rooms_text(f) }}</span>
+                  <span class="badge rounded-pill bg-danger-subtle text-danger ms-auto">{{ f.persons.count() }} pers.</span>
+                </li>
               {% else %}
-                <li class="small">Aucune</li>
+                <li class="list-group-item px-2 border-0">Aucune</li>
               {% endfor %}
             </ul>
 </div>
@@ -104,15 +108,15 @@
 <i class="bi bi-person-exclamation fs-4 me-2"></i>
 <div>
 <div class="fw-bold">Femmes isolées</div>
-<ul class="mb-0 ps-3">
+<ul class="list-group list-group-flush small mb-0">
               {% for p in isolated_women %}
-                <li class="small">{{ p.first_name }} {{ p.last_name }} — chambre {{ rooms_text(p.family) }}
-                  <span class="badge rounded-pill" style="background-color: {{ age_color(p) }};">
-                    {{ age_years(p.dob) }} ans
-                  </span>
-</li>
+                <li class="list-group-item list-group-item-action px-2 d-flex flex-wrap align-items-center gap-2 border-0">
+                  <span class="fw-semibold">{{ p.first_name }} {{ p.last_name }}</span>
+                  <span class="text-secondary">chambre {{ rooms_text(p.family) }}</span>
+                  <span class="badge rounded-pill" style="background-color: {{ age_color(p) }};">{{ age_years(p.dob) }} ans</span>
+                </li>
               {% else %}
-                <li class="small">Aucune</li>
+                <li class="list-group-item px-2 border-0">Aucune</li>
               {% endfor %}
             </ul>
 </div>
@@ -121,15 +125,15 @@
 <i class="bi bi-baby fs-4 me-2"></i>
 <div>
 <div class="fw-bold">Bébés de moins d'un an</div>
-<ul class="mb-0 ps-3">
+<ul class="list-group list-group-flush small mb-0">
               {% for p in baby_persons %}
-                <li class="small">{{ p.first_name }} {{ p.last_name }} — chambre {{ rooms_text(p.family) }}
-                  <span class="badge rounded-pill" style="background-color: {{ age_color(p) }};">
-                    {{ age_text(p.dob) }}
-                  </span>
-</li>
+                <li class="list-group-item list-group-item-action px-2 d-flex flex-wrap align-items-center gap-2 border-0">
+                  <span class="fw-semibold">{{ p.first_name }} {{ p.last_name }}</span>
+                  <span class="text-secondary">chambre {{ rooms_text(p.family) }}</span>
+                  <span class="badge rounded-pill" style="background-color: {{ age_color(p) }};">{{ age_text(p.dob) }}</span>
+                </li>
               {% else %}
-                <li class="small">Aucune</li>
+                <li class="list-group-item px-2 border-0">Aucune</li>
               {% endfor %}
             </ul>
 </div>


### PR DESCRIPTION
## Résumé
- Remplace les listes d’alertes par des `list-group` Bootstrap pour une présentation plus dynamique et alignée
- Ajoute des badges de chambre et de comptage pour mieux mettre en valeur les informations des familles, femmes isolées et bébés

## Tests
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b04431327883248df8bc5f479aba83