### PR TITLE
Corriger l'ordre des chambres du 1er étage

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -451,7 +451,7 @@
         <div class="d-flex gap-4 justify-content-center align-items-start">
           <div>
             <div class="grid-3 mb-2">
-              {% for r in [47,48,49] %}
+              {% for r in [49,48,47] %}
                 {{ room_box(r|string) }}
               {% endfor %}
             </div>
@@ -463,7 +463,7 @@
           </div>
           <div>
             <div class="grid-12 mb-2">
-              {% for r in [35,36,37,38,39,40,41,42,43,44,45,46] %}
+              {% for r in [46,45,44,43,42,41,40,39,38,37,36,35] %}
                 {{ room_box(r|string) }}
               {% endfor %}
             </div>


### PR DESCRIPTION
## Résumé
- Inverse l'ordre des chambres 47-49 pour le bâtiment gauche du 1er étage
- Inverse l'ordre des chambres 35-46 pour le bâtiment droit du 1er étage

## Tests
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1503e39908324bea462d14f0e6948