### PR TITLE
Renommer boutons de sauvegarde et import

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ L'objectif est de proposer une expérience conviviale en soignant autant **l'int
 - Recherche multi‑critères sur les familles et les personnes en cours d’hébergement.
 - Consultation des archives (familles/personnes sorties) avec filtres.
 - Export CSV des familles et des personnes.
-- Sauvegarde/Restauration JSON des données.
+- Sauvegarde/Chargement JSON des données.
 
 ## 🛠️ Installation
 
@@ -75,8 +75,8 @@ Le site est accessible sur [http://127.0.0.1:5000](http://127.0.0.1:5000).
 
 ## 💾 Sauvegarde & export
 
-- Bouton **Exporter** pour obtenir un fichier JSON de toutes les données.
-- Page **Restauration** pour réinjecter un fichier précédemment sauvegardé.
+- Bouton **Sauvegarder Kardex** pour obtenir un fichier JSON de toutes les données.
+- Page **Charger Kardex** pour réinjecter un fichier précédemment sauvegardé.
 - Export CSV des familles et des personnes disponible depuis la barre de navigation.
 
 ## ☁️ Hébergement

--- a/templates/base.html
+++ b/templates/base.html
@@ -55,8 +55,8 @@
           <li><a class="dropdown-item" href="{{ url_for('export_persons_csv') }}">Personnes (CSV)</a></li>
         </ul>
       </div>
-      <a class="btn btn-outline-success" href="{{ url_for('backup') }}"><i class="bi bi-save me-1"></i>Sauvegarde</a>
-      <a class="btn btn-outline-warning" href="{{ url_for('restore') }}"><i class="bi bi-arrow-counterclockwise me-1"></i>Restaurer</a>
+      <a class="btn btn-outline-success" href="{{ url_for('backup') }}"><i class="bi bi-save me-1"></i>Sauvegarder Kardex</a>
+      <a class="btn btn-outline-warning" href="{{ url_for('restore') }}"><i class="bi bi-arrow-counterclockwise me-1"></i>Charger Kardex</a>
       <a class="btn btn-outline-secondary" href="{{ url_for('config') }}"><i class="bi bi-gear me-1"></i>Configuration</a>
       <a class="btn btn-primary" href="{{ url_for('families_new') }}"><i class="bi bi-plus-lg me-1"></i>Nouvelle famille</a>
     </div>

--- a/templates/config.html
+++ b/templates/config.html
@@ -3,10 +3,10 @@
 {% block content %}
 <h1 class="h4 mb-4">Configuration</h1>
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('config_export') }}">Exporter</a>
+  <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('config_export') }}">Sauvegarder config</a>
   <form method="post" action="{{ url_for('config_import') }}" enctype="multipart/form-data" class="d-flex gap-2">
     <input type="file" name="file" class="form-control form-control-sm" required>
-    <button type="submit" class="btn btn-sm btn-outline-secondary">Importer</button>
+    <button type="submit" class="btn btn-sm btn-outline-secondary">Charger config</button>
   </form>
 </div>
 <form method="post">


### PR DESCRIPTION
## Résumé
- Renommage des boutons de configuration pour clarifier l'export et l'import
- Ajustement des intitulés de sauvegarde/restauration du Kardex
- Mise à jour de la documentation en conséquence

## Tests
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2cde93e088324becd27a67a9493d7