### PR TITLE
Gestion des alertes et simplification de la configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,9 +83,12 @@ DEFAULT_CONFIG = {
         "groups": [],  # [{"rooms": ["1","2"], "max": 3}, ...]
         "per_room": {},
     },
-    "persons": {},
     "alerts": {
         "baby_age": 1,
+        "show_free_rooms": True,
+        "show_overcrowded": True,
+        "show_isolated_women": True,
+        "show_baby_alert": True,
     },
 }
 
@@ -278,7 +281,12 @@ def set_theme(mode):
 @app.route("/")
 def dashboard():
     cfg = load_config()
-    baby_age = cfg.get("alerts", {}).get("baby_age", 1)
+    alerts_cfg = cfg.get("alerts", {})
+    baby_age = alerts_cfg.get("baby_age", 1)
+    show_free_rooms = alerts_cfg.get("show_free_rooms", True)
+    show_overcrowded = alerts_cfg.get("show_overcrowded", True)
+    show_isolated_women = alerts_cfg.get("show_isolated_women", True)
+    show_baby_alert = alerts_cfg.get("show_baby_alert", True)
     today = date.today()
     persons = Person.query.join(Family).filter(Family.departure_date.is_(None)).all()
 
@@ -501,6 +509,10 @@ def dashboard():
         isolated_women=isolated_women,
         baby_persons=baby_persons,
         baby_age=baby_age,
+        show_free_rooms=show_free_rooms,
+        show_overcrowded=show_overcrowded,
+        show_isolated_women=show_isolated_women,
+        show_baby_alert=show_baby_alert,
         free_rooms=free_rooms,
         room_data=room_data,
         rdc_rooms=rdc_rooms,
@@ -998,6 +1010,10 @@ def config():
         occup["per_room"] = per_room
 
         alerts = cfg["alerts"]
+        alerts["show_free_rooms"] = bool(request.form.get("show_free_rooms"))
+        alerts["show_overcrowded"] = bool(request.form.get("show_overcrowded"))
+        alerts["show_isolated_women"] = bool(request.form.get("show_isolated_women"))
+        alerts["show_baby_alert"] = bool(request.form.get("show_baby_alert"))
         try:
             alerts["baby_age"] = int(request.form.get("baby_age", 1))
         except ValueError:

--- a/config.json
+++ b/config.json
@@ -13,8 +13,11 @@
     "groups": [],
     "per_room": {}
   },
-  "persons": {},
   "alerts": {
-    "baby_age": 1
+    "baby_age": 1,
+    "show_free_rooms": true,
+    "show_overcrowded": true,
+    "show_isolated_women": true,
+    "show_baby_alert": true
   }
 }

--- a/templates/config.html
+++ b/templates/config.html
@@ -15,9 +15,6 @@
       <button class="nav-link active" id="hotel-tab" data-bs-toggle="tab" data-bs-target="#hotel" type="button" role="tab">Hôtel</button>
     </li>
     <li class="nav-item" role="presentation">
-      <button class="nav-link" id="persons-tab" data-bs-toggle="tab" data-bs-target="#persons" type="button" role="tab">Personnes</button>
-    </li>
-    <li class="nav-item" role="presentation">
       <button class="nav-link" id="alerts-tab" data-bs-toggle="tab" data-bs-target="#alerts" type="button" role="tab">Alertes</button>
     </li>
     <li class="nav-item" role="presentation">
@@ -100,15 +97,29 @@
         </div>
       </div>
     </div>
-    <div class="tab-pane fade" id="persons" role="tabpanel">
-      <p class="text-secondary">Paramètres personnes à définir.</p>
-    </div>
     <div class="tab-pane fade" id="alerts" role="tabpanel">
+      <div class="mb-3">
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="show_free_rooms" id="show_free_rooms" {% if config.alerts.show_free_rooms %}checked{% endif %}>
+          <label class="form-check-label" for="show_free_rooms">Chambres disponibles</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="show_overcrowded" id="show_overcrowded" {% if config.alerts.show_overcrowded %}checked{% endif %}>
+          <label class="form-check-label" for="show_overcrowded">Sur-occupation</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="show_isolated_women" id="show_isolated_women" {% if config.alerts.show_isolated_women %}checked{% endif %}>
+          <label class="form-check-label" for="show_isolated_women">Femmes isolées</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="show_baby_alert" id="show_baby_alert" {% if config.alerts.show_baby_alert %}checked{% endif %}>
+          <label class="form-check-label" for="show_baby_alert">Âge bébé</label>
+        </div>
+      </div>
       <div class="mb-3">
         <label class="form-label">Âge limite pour l'alerte bébé (années)</label>
         <input type="number" class="form-control" name="baby_age" value="{{ config.alerts.baby_age }}">
       </div>
-      <p class="text-secondary small">Alerte de sur-occupation configurable ultérieurement.</p>
     </div>
     <div class="tab-pane fade" id="disposition" role="tabpanel">
       <p class="text-secondary">Configuration de la disposition à venir.</p>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -81,6 +81,7 @@
     <div class="card shadow-soft p-3">
 <h6 class="mb-3"><i class="bi bi-exclamation-triangle me-2"></i>Alertes</h6>
 <div class="d-flex flex-column gap-3">
+{% if show_free_rooms %}
 <div class="alert alert-success d-flex align-items-start mb-0" role="alert">
 <i class="bi bi-door-open fs-4 me-2"></i>
 <div>
@@ -96,6 +97,8 @@
             {% endif %}
           </div>
 </div>
+{% endif %}
+{% if show_overcrowded %}
 <div class="alert alert-danger d-flex align-items-start mb-0" role="alert">
 <i class="bi bi-people-fill fs-4 me-2"></i>
 <div>
@@ -113,6 +116,8 @@
             </ul>
 </div>
 </div>
+{% endif %}
+{% if show_isolated_women %}
 <div class="alert alert-warning d-flex align-items-start mb-0" role="alert">
 <i class="bi bi-person-exclamation fs-4 me-2"></i>
 <div>
@@ -130,6 +135,8 @@
             </ul>
 </div>
 </div>
+{% endif %}
+{% if show_baby_alert %}
 <div class="alert alert-info d-flex align-items-start mb-0" role="alert">
 <i class="bi bi-baby fs-4 me-2"></i>
 <div>
@@ -147,6 +154,7 @@
             </ul>
 </div>
 </div>
+{% endif %}
 </div>
 </div>
 </div>


### PR DESCRIPTION
## Résumé
- Retrait de l’onglet *Personnes* de la page de configuration
- Ajout de cases à cocher pour choisir les alertes affichées sur le tableau de bord
- Affichage conditionnel des alertes selon la configuration enregistrée

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2d070e0088324bba6518b5950f35e