### PR TITLE
Corrige la duplication des étages dans la configuration

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -12,7 +12,16 @@ document.addEventListener('DOMContentLoaded', () => {
   let selected = null;
 
   function updateInput() {
-    const data = floors.map(f => ({ name: f.name, data: f.stage.toJSON() }));
+    const seen = new Set();
+    const data = [];
+    floors.forEach(f => {
+      if (!f.stage) return;
+      f.data = f.stage.toJSON();
+      const key = f.name.trim().toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      data.push({ name: f.name, data: f.data });
+    });
     layoutInput.value = JSON.stringify(data);
   }
 


### PR DESCRIPTION
## Résumé
- évite l'apparition d'étages en double dans l'éditeur de disposition
- conserve la configuration de chaque étage lors de la mise à jour

## Tests
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/js/layout.js`


------
https://chatgpt.com/codex/tasks/task_e_68b41e7f44f483249f5602b2f1dee2a9