### PR TITLE
Stop auto-creating floors in layout editor

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -202,15 +202,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  let initial = [];
   try {
-    const initial = JSON.parse(layoutInput.value || '[]');
-    if (initial.length) {
-      initial.forEach(f => addFloor(f.name, f.data));
-    } else {
-      addFloor();
-    }
+    initial = JSON.parse(layoutInput.value || "[]");
   } catch {
-    addFloor();
+    initial = [];
+  }
+  if (Array.isArray(initial) && initial.length) {
+    initial.forEach(f => addFloor(f.name, f.data));
   }
 });
 


### PR DESCRIPTION
## Summary
- Avoid adding initial empty floors when configuration layout has no data

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/js/layout.js`


------
https://chatgpt.com/codex/tasks/task_e_68b424d2a2dc83249fd0ebd54caeeebc