### PR TITLE
Empêche la création double d'étage

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -1,4 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
+  if (window.__layoutInit) return;
+  window.__layoutInit = true;
   const palette = document.getElementById('layout-palette');
   const floorNav = document.getElementById('floor-nav');
   const floorContainer = document.getElementById('floor-container');


### PR DESCRIPTION
## Résumé
- Évite l'initialisation multiple du module `layout.js`
- Corrige l'ajout d'étages en double dans l'onglet disposition

## Test
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4286cd4d4832494b3055e48e8fd0c