### PR TITLE
Ajout de boutons de zoom pour la disposition

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -8,6 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const widthInput = document.getElementById('cell_width');
   const heightInput = document.getElementById('cell_height');
   const trash = document.getElementById('layout-trash');
+  const zoomInBtn = document.getElementById('zoom-in');
+  const zoomOutBtn = document.getElementById('zoom-out');
   if (!palette || !floorNav || !floorContainer || !layoutInput) return;
 
   let floors = [];
@@ -30,6 +32,24 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function snap(v) {
     return Math.round(v / 10) * 10;
+  }
+
+  function zoomStage(stage, zoomIn) {
+    const scaleBy = 1.05;
+    const oldScale = stage.scaleX();
+    const pointer = { x: stage.width() / 2, y: stage.height() / 2 };
+    const mousePointTo = {
+      x: (pointer.x - stage.x()) / oldScale,
+      y: (pointer.y - stage.y()) / oldScale
+    };
+    const newScale = zoomIn ? oldScale * scaleBy : oldScale / scaleBy;
+    stage.scale({ x: newScale, y: newScale });
+    const newPos = {
+      x: pointer.x - mousePointTo.x * newScale,
+      y: pointer.y - mousePointTo.y * newScale
+    };
+    stage.position(newPos);
+    stage.batchDraw();
   }
 
   function overTrash(stage) {
@@ -186,6 +206,18 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   document.getElementById('add-floor').addEventListener('click', () => addFloor());
+
+  zoomInBtn?.addEventListener('click', () => {
+    if (currentIndex !== -1) {
+      zoomStage(floors[currentIndex].stage, true);
+    }
+  });
+
+  zoomOutBtn?.addEventListener('click', () => {
+    if (currentIndex !== -1) {
+      zoomStage(floors[currentIndex].stage, false);
+    }
+  });
 
   palette.querySelectorAll('.layout-item').forEach(item => {
     item.addEventListener('dragstart', e => {

--- a/templates/config.html
+++ b/templates/config.html
@@ -184,7 +184,17 @@
             </div>
           </div>
         <div class="flex-grow-1">
-          <ul class="nav nav-pills mb-2" id="floor-nav"></ul>
+          <div class="d-flex justify-content-between mb-2">
+            <ul class="nav nav-pills mb-0" id="floor-nav"></ul>
+            <div class="btn-group btn-group-sm">
+              <button type="button" class="btn btn-outline-secondary" id="zoom-in">
+                <i class="bi bi-zoom-in"></i>
+              </button>
+              <button type="button" class="btn btn-outline-secondary" id="zoom-out">
+                <i class="bi bi-zoom-out"></i>
+              </button>
+            </div>
+          </div>
           <div id="floor-container" class="border"></div>
         </div>
       </div>


### PR DESCRIPTION
## Résumé
- Ajout de deux boutons de zoom dans l'onglet *Disposition* pour faciliter la navigation.
- Ajout d'une fonction de zoom et des gestionnaires d'évènements associés dans `layout.js`.

## Tests
- `node --check static/js/layout.js`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b42ccc860c8324b7e21331c9f7364f