### PR TITLE
Corrige l'affichage des étages dans la configuration

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -265,17 +265,19 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  let initial = [];
+  let initialLayout = {};
   try {
-    initial = JSON.parse(layoutInput.value || "[]");
-    if (!Array.isArray(initial) && Array.isArray(initial?.floors)) {
-      initial = initial.floors;
-    }
+    initialLayout = JSON.parse(layoutInput.value || "{}");
   } catch {
-    initial = [];
+    initialLayout = {};
   }
-  if (Array.isArray(initial) && initial.length) {
-    initial.forEach(f => addFloor(f.name, f.data));
+  const initialFloors = Array.isArray(initialLayout?.floors)
+    ? initialLayout.floors
+    : Array.isArray(initialLayout)
+      ? initialLayout
+      : [];
+  if (initialFloors.length) {
+    initialFloors.forEach(f => addFloor(f.name, f.data));
   }
 });
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -198,7 +198,7 @@
           <div id="floor-container" class="border"></div>
         </div>
       </div>
-      <textarea name="layout_json" id="layout_json" hidden>{{ config.layout.floors|tojson }}</textarea>
+      <textarea name="layout_json" id="layout_json" hidden>{{ config.layout|tojson }}</textarea>
     </div>
   </div>
   <button type="submit" class="btn btn-primary mt-3">Enregistrer</button>


### PR DESCRIPTION
## Résumé
- Sérialise l'ensemble de la disposition dans le formulaire de configuration
- Initialise la disposition côté client à partir de l'objet complet pour afficher tous les étages

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b481d2d71c8324b83e19992ddb8423