### PR TITLE
Correction de l'affichage des étages supplémentaires

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -106,11 +106,22 @@ document.addEventListener('DOMContentLoaded', () => {
     floorContainer.innerHTML = '';
     const stageData = floors[index].data;
     let stage;
-    if (stageData) {
-      stage = Konva.Node.create(stageData, floorContainer);
-      stage.width(floorContainer.clientWidth);
-      stage.height(floorContainer.clientHeight);
-    } else {
+    try {
+      if (stageData) {
+        stage = Konva.Node.create(stageData, floorContainer);
+        stage.width(floorContainer.clientWidth);
+        stage.height(floorContainer.clientHeight);
+      } else {
+        stage = new Konva.Stage({
+          container: floorContainer,
+          width: floorContainer.clientWidth,
+          height: floorContainer.clientHeight
+        });
+        const layer = new Konva.Layer();
+        stage.add(layer);
+      }
+    } catch (err) {
+      console.error('Erreur lors du chargement de l\'étage', err);
       stage = new Konva.Stage({
         container: floorContainer,
         width: floorContainer.clientWidth,


### PR DESCRIPTION
## Résumé
- Gérer les erreurs lors de la création d'une scène Konva pour éviter l'arrêt du script
- Créer une scène vide en cas de données d'étage invalides afin que tous les étages soient listés

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b532d689a48324bc1aaf70be4a9326