### PR TITLE
Corriger l'erreur lors de l'enregistrement de la configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -1090,6 +1090,13 @@ def config():
         cell_w = layout["cell_width"]
         cell_h = layout["cell_height"]
         for f in floors_raw:
+            if isinstance(f, str):
+                try:
+                    f = json.loads(f)
+                except json.JSONDecodeError:
+                    continue
+            if not isinstance(f, dict):
+                continue
             name = (f.get("name") or "").strip()
             key = name.lower()
             if key in seen_names:


### PR DESCRIPTION
## Résumé
- Gérer les chaînes dans le JSON de disposition des étages.
- Ignorer les entrées invalides lors du traitement des étages pour éviter les erreurs d'attribut.

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5355dbf0083248396c48141acf935