### PR TITLE
Ajout de la sauvegarde et chargement de la disposition

### DIFF
--- a/app.py
+++ b/app.py
@@ -1026,6 +1026,58 @@ def config_import():
     return redirect(url_for("config"))
 
 
+@app.route("/layout/export")
+def layout_export():
+    cfg = load_config()
+    layout = cfg.get("layout", {})
+    resp = make_response(json.dumps(layout, ensure_ascii=False, indent=2))
+    resp.headers["Content-Type"] = "application/json; charset=utf-8"
+    resp.headers["Content-Disposition"] = "attachment; filename=layout.json"
+    return resp
+
+
+@app.route("/layout/import", methods=["POST"])
+def layout_import():
+    file = request.files.get("file")
+    if file:
+        try:
+            data = json.load(file.stream)
+        except json.JSONDecodeError:
+            data = None
+        if isinstance(data, dict) or isinstance(data, list):
+            cfg = load_config()
+            layout = cfg.setdefault("layout", {})
+            if isinstance(data, dict):
+                layout.update({k: v for k, v in data.items() if k != "floors"})
+                floors_raw = data.get("floors", [])
+            else:
+                floors_raw = data
+            floors: list[dict] = []
+            seen_names: set[str] = set()
+            cell_w = layout.get("cell_width", 80)
+            cell_h = layout.get("cell_height", 40)
+            for f in floors_raw:
+                if not isinstance(f, dict):
+                    continue
+                name = (f.get("name") or "").strip()
+                key = name.lower()
+                if key in seen_names:
+                    continue
+                seen_names.add(key)
+                stage_data = f.get("data")
+                rooms, width, height = extract_room_layout(stage_data, cell_w, cell_h)
+                floors.append({
+                    "name": name,
+                    "data": stage_data,
+                    "rooms": rooms,
+                    "width": width,
+                    "height": height,
+                })
+            layout["floors"] = floors
+            save_config(cfg)
+    return redirect(url_for("config"))
+
+
 @app.route("/config", methods=["GET", "POST"])
 def config():
     cfg = load_config()

--- a/templates/config.html
+++ b/templates/config.html
@@ -147,6 +147,13 @@
           background: var(--bs-danger-bg-subtle);
         }
       </style>
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('layout_export') }}">Sauvegarder disposition</a>
+        <form method="post" action="{{ url_for('layout_import') }}" enctype="multipart/form-data" class="d-flex gap-2">
+          <input type="file" name="file" class="form-control form-control-sm" required>
+          <button type="submit" class="btn btn-sm btn-outline-secondary">Charger disposition</button>
+        </form>
+      </div>
       <div class="row g-3 mb-3">
         <div class="col">
           <label class="form-label">Largeur des cases</label>


### PR DESCRIPTION
## Résumé
- possibilité d'exporter et d'importer la disposition via de nouvelles routes `/layout/export` et `/layout/import`
- ajout de boutons de sauvegarde/chargement dans l'onglet **Disposition** de la configuration

## Tests
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b537d1ed288324babe1734476d48b3