### PR TITLE
Permettre l'édition de la disposition après sauvegarde

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -67,6 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function setupGroup(group) {
+    group.draggable(true);
     group.on('dragmove', () => {
       if (overTrash(group.getStage())) {
         trash?.classList.add('dragover');


### PR DESCRIPTION
## Résumé
- Rendre les éléments du plan de l'hôtel toujours déplaçables en réactivant `draggable` lors du chargement.

## Tests
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b562116d188324812f67f852eee4a4