### PR TITLE
feat: add dashboard configuration options

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,6 +90,16 @@ DEFAULT_CONFIG = {
         "show_isolated_women": True,
         "show_baby_alert": True,
     },
+    "dashboard": {
+        "show_alerts": True,
+        "show_total_clients": True,
+        "show_birthdays": True,
+        "show_tenures": True,
+        "show_age_groups": True,
+        "show_room_layout": True,
+        "show_recent_families": True,
+        "sex_chart_diameter": 200,
+    },
     "layout": {
         "floors": [],
     },
@@ -330,11 +340,20 @@ def set_theme(mode):
 def dashboard():
     cfg = load_config()
     alerts_cfg = cfg.get("alerts", {})
+    dashboard_cfg = cfg.get("dashboard", {})
     baby_age = alerts_cfg.get("baby_age", 1)
     show_free_rooms = alerts_cfg.get("show_free_rooms", True)
     show_overcrowded = alerts_cfg.get("show_overcrowded", True)
     show_isolated_women = alerts_cfg.get("show_isolated_women", True)
     show_baby_alert = alerts_cfg.get("show_baby_alert", True)
+    show_alert_box = dashboard_cfg.get("show_alerts", True)
+    show_total_clients = dashboard_cfg.get("show_total_clients", True)
+    show_birthdays = dashboard_cfg.get("show_birthdays", True)
+    show_tenures = dashboard_cfg.get("show_tenures", True)
+    show_age_groups = dashboard_cfg.get("show_age_groups", True)
+    show_room_layout = dashboard_cfg.get("show_room_layout", True)
+    show_recent_families = dashboard_cfg.get("show_recent_families", True)
+    sex_chart_diameter = dashboard_cfg.get("sex_chart_diameter", 200)
     today = date.today()
     persons = Person.query.join(Family).filter(Family.departure_date.is_(None)).all()
 
@@ -558,6 +577,14 @@ def dashboard():
         show_overcrowded=show_overcrowded,
         show_isolated_women=show_isolated_women,
         show_baby_alert=show_baby_alert,
+        show_alert_box=show_alert_box,
+        show_total_clients=show_total_clients,
+        show_birthdays=show_birthdays,
+        show_tenures=show_tenures,
+        show_age_groups=show_age_groups,
+        show_room_layout=show_room_layout,
+        show_recent_families=show_recent_families,
+        sex_chart_diameter=sex_chart_diameter,
         free_rooms=free_rooms,
         room_data=room_data,
         layout=cfg.get("layout", {}),
@@ -1063,6 +1090,19 @@ def config():
             alerts["baby_age"] = int(request.form.get("baby_age", 1))
         except ValueError:
             alerts["baby_age"] = 1
+
+        dashboard_cfg = cfg.setdefault("dashboard", {})
+        dashboard_cfg["show_alerts"] = bool(request.form.get("show_alerts"))
+        dashboard_cfg["show_total_clients"] = bool(request.form.get("show_total_clients"))
+        dashboard_cfg["show_birthdays"] = bool(request.form.get("show_birthdays"))
+        dashboard_cfg["show_tenures"] = bool(request.form.get("show_tenures"))
+        dashboard_cfg["show_age_groups"] = bool(request.form.get("show_age_groups"))
+        dashboard_cfg["show_room_layout"] = bool(request.form.get("show_room_layout"))
+        dashboard_cfg["show_recent_families"] = bool(request.form.get("show_recent_families"))
+        try:
+            dashboard_cfg["sex_chart_diameter"] = int(request.form.get("sex_chart_diameter", 200))
+        except ValueError:
+            dashboard_cfg["sex_chart_diameter"] = 200
 
         layout = cfg.setdefault("layout", {})
         layout_json = request.form.get("layout_json", "[]")

--- a/config.json
+++ b/config.json
@@ -20,6 +20,16 @@
     "show_isolated_women": true,
     "show_baby_alert": true
   },
+  "dashboard": {
+    "show_alerts": true,
+    "show_total_clients": true,
+    "show_birthdays": true,
+    "show_tenures": true,
+    "show_age_groups": true,
+    "show_room_layout": true,
+    "show_recent_families": true,
+    "sex_chart_diameter": 200
+  },
   "layout": {
     "floors": []
   }

--- a/templates/config.html
+++ b/templates/config.html
@@ -18,6 +18,9 @@
       <button class="nav-link" id="alerts-tab" data-bs-toggle="tab" data-bs-target="#alerts" type="button" role="tab">Alertes</button>
     </li>
     <li class="nav-item" role="presentation">
+      <button class="nav-link" id="dashboard-tab" data-bs-toggle="tab" data-bs-target="#dashboard" type="button" role="tab">Dashboard</button>
+    </li>
+    <li class="nav-item" role="presentation">
       <button class="nav-link" id="disposition-tab" data-bs-toggle="tab" data-bs-target="#disposition" type="button" role="tab">Disposition</button>
     </li>
   </ul>
@@ -117,8 +120,44 @@
         </div>
       </div>
       <div class="mb-3">
-        <label class="form-label">Âge limite pour l'alerte bébé (années)</label>
-        <input type="number" class="form-control" name="baby_age" value="{{ config.alerts.baby_age }}">
+      <label class="form-label">Âge limite pour l'alerte bébé (années)</label>
+      <input type="number" class="form-control" name="baby_age" value="{{ config.alerts.baby_age }}">
+    </div>
+    </div>
+    <div class="tab-pane fade" id="dashboard" role="tabpanel">
+      <div class="mb-3">
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="show_alerts" id="show_alerts" {% if config.dashboard.show_alerts %}checked{% endif %}>
+          <label class="form-check-label" for="show_alerts">Alertes</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="show_total_clients" id="show_total_clients" {% if config.dashboard.show_total_clients %}checked{% endif %}>
+          <label class="form-check-label" for="show_total_clients">Total clients</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="show_birthdays" id="show_birthdays" {% if config.dashboard.show_birthdays %}checked{% endif %}>
+          <label class="form-check-label" for="show_birthdays">Anniversaires</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="show_tenures" id="show_tenures" {% if config.dashboard.show_tenures %}checked{% endif %}>
+          <label class="form-check-label" for="show_tenures">Ancienneté</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="show_age_groups" id="show_age_groups" {% if config.dashboard.show_age_groups %}checked{% endif %}>
+          <label class="form-check-label" for="show_age_groups">Tranches d’âge</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="show_room_layout" id="show_room_layout" {% if config.dashboard.show_room_layout %}checked{% endif %}>
+          <label class="form-check-label" for="show_room_layout">Disposition des chambres</label>
+        </div>
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="show_recent_families" id="show_recent_families" {% if config.dashboard.show_recent_families %}checked{% endif %}>
+          <label class="form-check-label" for="show_recent_families">Familles récentes</label>
+        </div>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Diamètre du graphique des sexes (px)</label>
+        <input type="number" class="form-control" name="sex_chart_diameter" value="{{ config.dashboard.sex_chart_diameter }}">
       </div>
     </div>
     <div class="tab-pane fade" id="disposition" role="tabpanel">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -50,6 +50,7 @@
     {% endif %}
   {% endmacro %}
   <div class="row g-4">
+{% if show_alert_box %}
 <div class="col-12 col-xl-4 d-flex flex-column">
     <div class="card shadow-soft p-3">
 <h6 class="mb-3"><i class="bi bi-exclamation-triangle me-2"></i>Alertes</h6>
@@ -131,7 +132,9 @@
 </div>
 </div>
 </div>
+{% endif %}
 <div class="col-12 col-xl-4">
+    {% if show_total_clients %}
     <div class="card shadow-soft p-3">
 <div class="d-flex align-items-center">
 <div class="display-6 me-3 text-info"><i class="bi bi-people-fill"></i></div>
@@ -145,10 +148,12 @@
 </div>
 </div>
 </div>
+    {% endif %}
     <div class="card shadow-soft p-3 mt-4">
 <h6 class="mb-3"><i class="bi bi-gender-ambiguous me-2"></i>Répartition par sexe</h6>
-<canvas height="200" id="sexChart"></canvas>
+<canvas id="sexChart" width="{{ sex_chart_diameter }}" height="{{ sex_chart_diameter }}"></canvas>
 </div>
+    {% if show_age_groups %}
     <div class="card shadow-soft p-3 mt-4">
 <h6 class="mb-3"><i class="bi bi-activity me-2"></i>Tranches d’âge</h6>
 <canvas height="200" id="ageChart"></canvas>
@@ -163,10 +168,12 @@
   </div>
 </div>
 </div>
+    {% endif %}
 
 </div>
 <div class="col-12 col-xl-4">
 
+    {% if show_birthdays %}
     <div class="card shadow-soft p-3">
 <h6 class="mb-3"><i class="bi bi-cake2 me-2"></i>Anniversaires</h6>
         {% if birthdays_today %}
@@ -247,7 +254,9 @@
             </ul>
 </div>
 </div>
-</div>
+    </div>
+    {% endif %}
+    {% if show_tenures %}
     <div class="card shadow-soft p-3 mt-4">
 <h6 class="mb-3"><i class="bi bi-hourglass-split me-2"></i>Ancienneté</h6>
 <ul class="nav nav-pills mb-3" id="seniorityTab" role="tablist">
@@ -322,7 +331,8 @@
       </tbody>
     </table>
   </div>
-</div>
+    </div>
+    {% endif %}
 </div>
 </div>
 <div class="tab-pane fade" id="new" role="tabpanel">
@@ -395,6 +405,7 @@
  </div></div>
  </div>
 
+    {% if show_room_layout %}
     <div class="card shadow-soft p-3 mt-4">
       <h6 class="mb-3"><i class="bi bi-building me-2"></i>Disposition des chambres</h6>
       <div id="room-layout">
@@ -412,7 +423,9 @@
         {% endfor %}
       </div>
     </div>
+    {% endif %}
 
+    {% if show_recent_families %}
     <div class="card shadow-soft p-3 mt-4">
   <div class="d-flex align-items-center justify-content-between">
     <h6 class="mb-0"><i class="bi bi-clock-history me-2"></i>Familles récentes</h6>
@@ -444,6 +457,7 @@
     </table>
   </div>
 </div>
+    {% endif %}
 {% for f in families %}
 <div class="modal fade" id="famModal{{ f.id }}" tabindex="-1">
   <div class="modal-dialog">


### PR DESCRIPTION
## Summary
- allow toggling dashboard boxes and sex chart size
- add dashboard tab in configuration

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b586a701888324a30d16af0612e75c