### PR TITLE
Fix sex chart size and store dashboard layout settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -99,6 +99,16 @@ DEFAULT_CONFIG = {
         "show_room_layout": True,
         "show_recent_families": True,
         "sex_chart_diameter": 200,
+        "layout": {
+            "alerts": {"order": 1, "width": 4},
+            "total_clients": {"order": 2, "width": 4},
+            "birthdays": {"order": 3, "width": 4},
+            "sex_chart": {"order": 4, "width": 4},
+            "tenures": {"order": 5, "width": 4},
+            "age_groups": {"order": 6, "width": 4},
+            "room_layout": {"order": 7, "width": 4},
+            "recent_families": {"order": 8, "width": 4},
+        },
     },
     "layout": {
         "floors": [],
@@ -354,6 +364,7 @@ def dashboard():
     show_room_layout = dashboard_cfg.get("show_room_layout", True)
     show_recent_families = dashboard_cfg.get("show_recent_families", True)
     sex_chart_diameter = dashboard_cfg.get("sex_chart_diameter", 200)
+    box_layout = dashboard_cfg.get("layout", {})
     today = date.today()
     persons = Person.query.join(Family).filter(Family.departure_date.is_(None)).all()
 
@@ -588,6 +599,7 @@ def dashboard():
         free_rooms=free_rooms,
         room_data=room_data,
         layout=cfg.get("layout", {}),
+        box_layout=box_layout,
         Person=Person,
     )
 
@@ -1103,6 +1115,27 @@ def config():
             dashboard_cfg["sex_chart_diameter"] = int(request.form.get("sex_chart_diameter", 200))
         except ValueError:
             dashboard_cfg["sex_chart_diameter"] = 200
+        box_layout: dict[str, dict[str, int]] = {}
+        for key in [
+            "alerts",
+            "total_clients",
+            "birthdays",
+            "sex_chart",
+            "tenures",
+            "age_groups",
+            "room_layout",
+            "recent_families",
+        ]:
+            try:
+                order = int(request.form.get(f"order_{key}", 0))
+            except ValueError:
+                order = 0
+            try:
+                width = int(request.form.get(f"width_{key}", 4))
+            except ValueError:
+                width = 4
+            box_layout[key] = {"order": order, "width": width}
+        dashboard_cfg["layout"] = box_layout
 
         layout = cfg.setdefault("layout", {})
         layout_json = request.form.get("layout_json", "[]")

--- a/config.json
+++ b/config.json
@@ -28,7 +28,17 @@
     "show_age_groups": true,
     "show_room_layout": true,
     "show_recent_families": true,
-    "sex_chart_diameter": 200
+    "sex_chart_diameter": 200,
+    "layout": {
+      "alerts": {"order": 1, "width": 4},
+      "total_clients": {"order": 2, "width": 4},
+      "birthdays": {"order": 3, "width": 4},
+      "sex_chart": {"order": 4, "width": 4},
+      "tenures": {"order": 5, "width": 4},
+      "age_groups": {"order": 6, "width": 4},
+      "room_layout": {"order": 7, "width": 4},
+      "recent_families": {"order": 8, "width": 4}
+    }
   },
   "layout": {
     "floors": []

--- a/templates/config.html
+++ b/templates/config.html
@@ -159,6 +159,58 @@
         <label class="form-label">Diamètre du graphique des sexes (px)</label>
         <input type="number" class="form-control" name="sex_chart_diameter" value="{{ config.dashboard.sex_chart_diameter }}">
       </div>
+      <div class="mb-3">
+        <label class="form-label">Disposition des boxes</label>
+        <div class="table-responsive">
+          <table class="table table-sm align-middle mb-0">
+            <thead>
+              <tr><th>Boxe</th><th>Ordre</th><th>Largeur (1-12)</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Alertes</td>
+                <td><input type="number" class="form-control" name="order_alerts" value="{{ config.dashboard.layout.alerts.order }}"></td>
+                <td><input type="number" class="form-control" name="width_alerts" value="{{ config.dashboard.layout.alerts.width }}"></td>
+              </tr>
+              <tr>
+                <td>Total clients</td>
+                <td><input type="number" class="form-control" name="order_total_clients" value="{{ config.dashboard.layout.total_clients.order }}"></td>
+                <td><input type="number" class="form-control" name="width_total_clients" value="{{ config.dashboard.layout.total_clients.width }}"></td>
+              </tr>
+              <tr>
+                <td>Anniversaires</td>
+                <td><input type="number" class="form-control" name="order_birthdays" value="{{ config.dashboard.layout.birthdays.order }}"></td>
+                <td><input type="number" class="form-control" name="width_birthdays" value="{{ config.dashboard.layout.birthdays.width }}"></td>
+              </tr>
+              <tr>
+                <td>Répartition par sexe</td>
+                <td><input type="number" class="form-control" name="order_sex_chart" value="{{ config.dashboard.layout.sex_chart.order }}"></td>
+                <td><input type="number" class="form-control" name="width_sex_chart" value="{{ config.dashboard.layout.sex_chart.width }}"></td>
+              </tr>
+              <tr>
+                <td>Ancienneté</td>
+                <td><input type="number" class="form-control" name="order_tenures" value="{{ config.dashboard.layout.tenures.order }}"></td>
+                <td><input type="number" class="form-control" name="width_tenures" value="{{ config.dashboard.layout.tenures.width }}"></td>
+              </tr>
+              <tr>
+                <td>Tranches d’âge</td>
+                <td><input type="number" class="form-control" name="order_age_groups" value="{{ config.dashboard.layout.age_groups.order }}"></td>
+                <td><input type="number" class="form-control" name="width_age_groups" value="{{ config.dashboard.layout.age_groups.width }}"></td>
+              </tr>
+              <tr>
+                <td>Disposition des chambres</td>
+                <td><input type="number" class="form-control" name="order_room_layout" value="{{ config.dashboard.layout.room_layout.order }}"></td>
+                <td><input type="number" class="form-control" name="width_room_layout" value="{{ config.dashboard.layout.room_layout.width }}"></td>
+              </tr>
+              <tr>
+                <td>Familles récentes</td>
+                <td><input type="number" class="form-control" name="order_recent_families" value="{{ config.dashboard.layout.recent_families.order }}"></td>
+                <td><input type="number" class="form-control" name="width_recent_families" value="{{ config.dashboard.layout.recent_families.width }}"></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
     <div class="tab-pane fade" id="disposition" role="tabpanel">
       <style>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -519,6 +519,7 @@ document.addEventListener('DOMContentLoaded', () => {
       ]
     },
     options: {
+      responsive: false,
       plugins: {
         legend: { position: 'bottom' },
         datalabels: {


### PR DESCRIPTION
## Summary
- Activer le redimensionnement du graphique de répartition par sexe via la configuration
- Ajouter des champs de configuration pour l'ordre et la largeur des tuiles du tableau de bord

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b58aba2e1c8324a48e0477e81f3f7f