### PR TITLE
fix: allow editing layout after save

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -1,6 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-  if (window.__layoutInit) return;
-  window.__layoutInit = true;
   const palette = document.getElementById('layout-palette');
   const floorNav = document.getElementById('floor-nav');
   const floorContainer = document.getElementById('floor-container');


### PR DESCRIPTION
## Summary
- ensure layout editor initializes on each visit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7eec4e778832491d761ca3c5492fa