### PR TITLE
Fix: conserver les étages existants lors de l'édition de la disposition

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -18,8 +18,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const seen = new Set();
     const data = [];
     floors.forEach(f => {
-      if (!f.stage) return;
-      f.data = f.stage.toJSON();
+      if (f.stage) {
+        f.data = f.stage.toJSON();
+      }
       const key = f.name.trim().toLowerCase();
       if (seen.has(key)) return;
       seen.add(key);


### PR DESCRIPTION
## Résumé
- Conserve les données des étages non affichés lors de la mise à jour du champ `layout_json`
- Évite la perte ou la duplication d'étages lors de l'édition d'une disposition

## Test
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7f20a37b48324a90b075c88bd908b