### PR TITLE
Empêcher les doublons d'étages

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -167,11 +167,13 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function addFloor(name, data, select = true) {
+    const existing = new Set(floors.map(f => f.name.trim().toLowerCase()));
     if (!name) {
-      const existing = new Set(floors.map(f => f.name.trim().toLowerCase()));
       let idx = floors.length + 1;
       while (existing.has(`étage ${idx}`)) idx++;
       name = `Étage ${idx}`;
+    } else if (existing.has(name.trim().toLowerCase())) {
+      return;
     }
     const floor = { name, data: data || null, stage: null };
     floors.push(floor);
@@ -293,7 +295,14 @@ document.addEventListener('DOMContentLoaded', () => {
     initialFloors = [];
   }
   if (Array.isArray(initialFloors) && initialFloors.length) {
-    initialFloors.forEach(f => addFloor(f.name, f.data, false));
+    const seen = new Set();
+    const uniqueFloors = initialFloors.filter(f => {
+      const key = f?.name?.trim().toLowerCase();
+      if (!key || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+    uniqueFloors.forEach(f => addFloor(f.name, f.data, false));
     loadFloor(0);
   }
 });


### PR DESCRIPTION
## Résumé
- Filtre les étages initiaux pour ne garder qu'un nom unique (insensible à la casse)
- Bloque l'ajout d'un étage si un autre porte déjà le même nom

## Tests
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7f62bcfa083248c2d46706e90c0cc