### PR TITLE
Évite les doublons d'étages lors du chargement

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -295,14 +295,15 @@ document.addEventListener('DOMContentLoaded', () => {
     initialFloors = [];
   }
   if (Array.isArray(initialFloors) && initialFloors.length) {
+    floors.length = 0;
+    floorNav.innerHTML = '';
     const seen = new Set();
-    const uniqueFloors = initialFloors.filter(f => {
+    initialFloors.forEach(f => {
       const key = f?.name?.trim().toLowerCase();
-      if (!key || seen.has(key)) return false;
+      if (!key || seen.has(key)) return;
       seen.add(key);
-      return true;
+      addFloor(f.name, f.data, false);
     });
-    uniqueFloors.forEach(f => addFloor(f.name, f.data, false));
     loadFloor(0);
   }
 });


### PR DESCRIPTION
## Résumé
- Réinitialise la liste des étages et la navigation avant le chargement initial.
- Filtre les doublons d'étages par nom (insensible à la casse) avant création.

## Tests
- `python -m py_compile app.py`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b99c622a508324bf4d07e97d51c699