### PR TITLE
Sauvegarde de l'étage avant changement ou fermeture

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -30,6 +30,8 @@ document.addEventListener('DOMContentLoaded', () => {
     layoutInput.value = JSON.stringify(data);
   }
 
+  window.addEventListener('beforeunload', () => updateInput());
+
   function snap(v) {
     return Math.round(v / 10) * 10;
   }
@@ -100,6 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function loadFloor(index) {
+    updateInput();
     currentIndex = index;
     floorNav.querySelectorAll('.nav-link').forEach((b, i) => {
       b.classList.toggle('active', i === index);
@@ -163,7 +166,6 @@ document.addEventListener('DOMContentLoaded', () => {
         selected = null;
       }
     });
-    updateInput();
   }
 
   function addFloor(name, data, select = true) {


### PR DESCRIPTION
## Résumé
- Appelle `updateInput()` avant la fermeture de la page pour enregistrer les dernières modifications.
- Sauvegarde l'étage courant dès l'appel à `loadFloor()` avant de basculer.
- Vérifie que la sérialisation Konva conserve numéros et positions après rechargement.

## Tests
- `node - <<'NODE' ...` (positions identiques)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b99d4cec6c832485ca0b1a935ff1e7