### PR TITLE
Recentre les étiquettes de pièces lors du renommage

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -93,6 +93,10 @@ document.addEventListener('DOMContentLoaded', () => {
       const val = prompt('Nom de la pièce', text.text());
       if (val !== null) {
         text.text(val);
+        const rect = group.findOne('Rect');
+        const h = rect.height();
+        text.y((h - text.height()) / 2);
+        group.getLayer().draw();
         updateInput();
       }
     });


### PR DESCRIPTION
## Résumé
- Recalcul de la position verticale du texte après renommage d'une pièce.
- Rafraîchissement de la couche Konva pour afficher immédiatement les changements.

## Tests
- `python -m py_compile $(git ls-files '*.py')`
- `node --check static/js/layout.js`
- `python playwright attempt` (échec : dépendances système manquantes)


------
https://chatgpt.com/codex/tasks/task_e_68b99e450f8083249cbe1f6a47a296c7