### PR TITLE
Fix duplicate floors and layout editing

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -298,8 +298,9 @@
   </div>
   <button type="submit" class="btn btn-primary mt-3">Enregistrer</button>
 </form>
+{% endblock %}
+
 {% block scripts %}
 <script src="https://cdn.jsdelivr.net/npm/konva@9/konva.min.js"></script>
 <script src="{{ url_for('static', filename='js/layout.js') }}"></script>
-{% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Avoid duplicate floor creation by loading layout.js only once in the config page
- Ensure layout disposition edits persist after saving

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9a0d832f083249f253ef8287ba177