### PR TITLE
Corriger la réédition des chambres dans la disposition

### DIFF
--- a/static/js/layout.js
+++ b/static/js/layout.js
@@ -139,7 +139,7 @@ document.addEventListener('DOMContentLoaded', () => {
       stage.add(layer);
     }
     floors[index].stage = stage;
-    stage.find('Group').each(g => setupGroup(g));
+    stage.find('Group').forEach(g => setupGroup(g));
 
     stage.on('mousedown', e => {
       if (e.evt.shiftKey) {


### PR DESCRIPTION
## Résumé
- Réinitialise les événements des éléments de la disposition après rechargement en remplaçant l'appel `each` par `forEach`.

## Tests
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b9a5ee9b888324bc9755e3ea284c5b